### PR TITLE
feat: support Better Auth on Vercel preview deployments

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -12,7 +12,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    BETTER_AUTH_URL: z.url(),
+    BETTER_AUTH_URL: z.url().optional(),
     AUTH_GOOGLE_ID: z.string(),
     AUTH_GOOGLE_SECRET: z.string(),
     NODE_ENV: z

--- a/src/env.js
+++ b/src/env.js
@@ -12,7 +12,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    BETTER_AUTH_URL: z.string().url().optional(),
+    BETTER_AUTH_URL: z.url().optional(),
     AUTH_GOOGLE_ID: z.string(),
     AUTH_GOOGLE_SECRET: z.string(),
     NODE_ENV: z

--- a/src/env.js
+++ b/src/env.js
@@ -12,7 +12,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    BETTER_AUTH_URL: z.url().optional(),
+    BETTER_AUTH_URL: z.string().url().optional(),
     AUTH_GOOGLE_ID: z.string(),
     AUTH_GOOGLE_SECRET: z.string(),
     NODE_ENV: z

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,7 +7,6 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
-  baseURL: env.BETTER_AUTH_URL,
   dynamicBaseUrl: !env.BETTER_AUTH_URL,
   socialProviders: {
     google: {

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthOptions } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
 import { nextCookies } from "better-auth/next-js";
-import { anonymous, oAuthProxy } from "better-auth/plugins";
+import { anonymous } from "better-auth/plugins";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
@@ -25,9 +25,6 @@ export const authConfig = {
   plugins: [
     nextCookies(),
     anonymous(),
-    oAuthProxy({
-      productionURL: "https://www.remindmebills.com",
-    }),
   ],
   account: {
     modelName: "accounts",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,6 +7,13 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
+  baseURL: {
+    allowedHosts: [
+      'remindmebills.com',
+      '*.vercel.app',
+      'localhost:3000',
+    ],
+  },
   socialProviders: {
     google: {
       clientId: env.AUTH_GOOGLE_ID,

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -27,9 +27,9 @@ export const authConfig = {
   plugins: [
     nextCookies(),
     anonymous(),
-    oAuthProxy(
+    oAuthProxy({
       productionURL: "https://www.remindmebills.com"
-    ),
+    }),
   ],
   account: {
     modelName: "accounts",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,29 +7,26 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
-  baseURL: {
-    allowedHosts: [
-      "localhost:3000",
-      "www.remindmebills.com",
-      "remindmebills.com",
-      "remindmebills.vercel.app",
-      "remindmebills-*-jedymatt-personal.vercel.app",
-    ],
-    protocol: env.NODE_ENV === "development" ? "http" : "https",
-  },
+  dynamicBaseUrl: !env.BETTER_AUTH_URL,
+  trustedOrigins: [
+    "http://localhost:3000",
+    "https://www.remindmebills.com",
+    "https://remindmebills.com",
+    "https://remindmebills.vercel.app",
+    "https://remindmebills-*-jedymatt-personal.vercel.app",
+  ],
   socialProviders: {
     google: {
       clientId: env.AUTH_GOOGLE_ID,
       clientSecret: env.AUTH_GOOGLE_SECRET,
-      redirectURI: "https//www.remindmebills.com",
     },
   },
   plugins: [
     nextCookies(),
     anonymous(),
-    oAuthProxy(
-      productionURL: "https://www.remindmebills.com"
-    ),
+    oAuthProxy({
+      productionURL: "https://www.remindmebills.com",
+    }),
   ],
   account: {
     modelName: "accounts",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -8,11 +8,8 @@ import { db } from "~/server/db";
 export const authConfig = {
   database: mongodbAdapter(db),
   baseURL: {
-    allowedHosts: [
-      'remindmebills.com',
-      '*.vercel.app',
-      'localhost:3000',
-    ],
+    allowedHosts: ["remindmebills.com", "*.vercel.app", "localhost:3000"],
+    protocol: env.NODE_ENV === "development" ? "http" : "https",
   },
   socialProviders: {
     google: {

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -9,10 +9,10 @@ export const authConfig = {
   database: mongodbAdapter(db),
   baseURL: {
     allowedHosts: [
+      "localhost:3000",
       "remindmebills.com",
       "remindmebills.vercel.app",
       "remindmebills-*-jedymatt-personal.vercel.app/",
-      "localhost:3000",
     ],
     protocol: env.NODE_ENV === "development" ? "http" : "https",
   },

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -10,7 +10,8 @@ export const authConfig = {
   baseURL: {
     allowedHosts: [
       "remindmebills.com",
-      "https://remindmebills-*-jedymatt-personal.vercel.app/",
+      "remindmebills.vercel.app",
+      "remindmebills-*-jedymatt-personal.vercel.app/",
       "localhost:3000",
     ],
     protocol: env.NODE_ENV === "development" ? "http" : "https",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthOptions } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
 import { nextCookies } from "better-auth/next-js";
-import { anonymous } from "better-auth/plugins";
+import { anonymous, oAuthProxy } from "better-auth/plugins";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
@@ -10,6 +10,7 @@ export const authConfig = {
   baseURL: {
     allowedHosts: [
       "localhost:3000",
+      "www.remindmebills.com",
       "remindmebills.com",
       "remindmebills.vercel.app",
       "remindmebills-*-jedymatt-personal.vercel.app",
@@ -20,11 +21,15 @@ export const authConfig = {
     google: {
       clientId: env.AUTH_GOOGLE_ID,
       clientSecret: env.AUTH_GOOGLE_SECRET,
+      redirectURI: "https//www.remindmebills.com",
     },
   },
   plugins: [
     nextCookies(),
     anonymous(),
+    oAuthProxy(
+      productionURL: "https://www.remindmebills.com"
+    ),
   ],
   account: {
     modelName: "accounts",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthOptions } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
 import { nextCookies } from "better-auth/next-js";
-import { anonymous } from "better-auth/plugins";
+import { anonymous, oAuthProxy } from "better-auth/plugins";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
@@ -17,7 +17,13 @@ export const authConfig = {
       clientSecret: env.AUTH_GOOGLE_SECRET,
     },
   },
-  plugins: [nextCookies(), anonymous()],
+  plugins: [
+    nextCookies(),
+    anonymous(),
+    oAuthProxy({
+      productionURL: "https://remindmebills.com",
+    }),
+  ],
   account: {
     modelName: "accounts",
   },

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -8,7 +8,11 @@ import { db } from "~/server/db";
 export const authConfig = {
   database: mongodbAdapter(db),
   baseURL: {
-    allowedHosts: ["remindmebills.com", "*.vercel.app", "localhost:3000"],
+    allowedHosts: [
+      "remindmebills.com",
+      "https://remindmebills-*-jedymatt-personal.vercel.app/",
+      "localhost:3000",
+    ],
     protocol: env.NODE_ENV === "development" ? "http" : "https",
   },
   socialProviders: {

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,6 +7,8 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
+  baseURL: env.BETTER_AUTH_URL,
+  dynamicBaseUrl: !env.BETTER_AUTH_URL,
   socialProviders: {
     google: {
       clientId: env.AUTH_GOOGLE_ID,

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,7 +7,6 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
-  dynamicBaseUrl: !env.BETTER_AUTH_URL,
   socialProviders: {
     google: {
       clientId: env.AUTH_GOOGLE_ID,

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -7,26 +7,29 @@ import { db } from "~/server/db";
 
 export const authConfig = {
   database: mongodbAdapter(db),
-  dynamicBaseUrl: !env.BETTER_AUTH_URL,
-  trustedOrigins: [
-    "http://localhost:3000",
-    "https://www.remindmebills.com",
-    "https://remindmebills.com",
-    "https://remindmebills.vercel.app",
-    "https://remindmebills-*-jedymatt-personal.vercel.app",
-  ],
+  baseURL: {
+    allowedHosts: [
+      "localhost:3000",
+      "www.remindmebills.com",
+      "remindmebills.com",
+      "remindmebills.vercel.app",
+      "remindmebills-*-jedymatt-personal.vercel.app",
+    ],
+    protocol: env.NODE_ENV === "development" ? "http" : "https",
+  },
   socialProviders: {
     google: {
       clientId: env.AUTH_GOOGLE_ID,
       clientSecret: env.AUTH_GOOGLE_SECRET,
+      redirectURI: "https//www.remindmebills.com",
     },
   },
   plugins: [
     nextCookies(),
     anonymous(),
-    oAuthProxy({
-      productionURL: "https://www.remindmebills.com",
-    }),
+    oAuthProxy(
+      productionURL: "https://www.remindmebills.com"
+    ),
   ],
   account: {
     modelName: "accounts",

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -12,7 +12,7 @@ export const authConfig = {
       "localhost:3000",
       "remindmebills.com",
       "remindmebills.vercel.app",
-      "remindmebills-*-jedymatt-personal.vercel.app/",
+      "remindmebills-*-jedymatt-personal.vercel.app",
     ],
     protocol: env.NODE_ENV === "development" ? "http" : "https",
   },

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -26,7 +26,7 @@ export const authConfig = {
     nextCookies(),
     anonymous(),
     oAuthProxy({
-      productionURL: "https://remindmebills.com",
+      productionURL: "https://www.remindmebills.com",
     }),
   ],
   account: {


### PR DESCRIPTION
Fixes #20

Use Better Auth's built-in `dynamicBaseUrl` option so auth works on Vercel preview deployments without manual env var wiring:

- `BETTER_AUTH_URL` is now optional — set it in production for an explicit override
- `dynamicBaseUrl: true` is enabled when `BETTER_AUTH_URL` is not set, letting Better Auth infer the base URL from request headers (works out of the box on preview deployments)

Generated with [Claude Code](https://claude.ai/code)