### PR TITLE
fix: bill date-correctness (Next Bill today, due-date highlight, monthly month-end)

### DIFF
--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatDate, isEqual, subDays } from "date-fns";
+import { formatDate, isSameDay, subDays } from "date-fns";
 import { sumBy } from "lodash";
 import { EyeClosedIcon, EyeIcon, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -54,7 +54,7 @@ function BillRowItem({
   onClick: () => void;
   onToggleExclude: () => void;
 }) {
-  const isDue = isEqual(bill.date, payDate);
+  const isDue = isSameDay(bill.date, payDate);
 
   return (
     <li

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -7,7 +7,7 @@ import {
   PiggyBank,
   Wallet,
 } from "lucide-react";
-import { formatDate } from "date-fns";
+import { formatDate, startOfDay } from "date-fns";
 import { sumBy } from "lodash";
 import { Card, CardContent } from "~/components/ui/card";
 import { createPayRule, computeBillsInPeriod } from "~/lib/bill-utils";
@@ -37,11 +37,11 @@ export function FinancialSummaryCards({
 
     const periodBills = computeBillsInPeriod(bills, currentPay, nextPayDate);
 
-    // Find the nearest upcoming bill (today or future)
-    const now = new Date();
-    const upcoming = periodBills.find(
-      (b) => b.date >= now,
-    );
+    // Find the nearest upcoming bill (today or future). Compare on day
+    // granularity: bill dates are at midnight, so `b.date >= new Date()` would
+    // drop a bill due today once the wall clock passes midnight.
+    const today = startOfDay(new Date());
+    const upcoming = periodBills.find((b) => b.date >= today);
 
     return { currentPeriodBills: periodBills, nextBill: upcoming ?? null };
   }, [incomeProfile, bills]);

--- a/src/components/playgroundBillList.tsx
+++ b/src/components/playgroundBillList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatDate, isEqual, subDays } from "date-fns";
+import { formatDate, isSameDay, subDays } from "date-fns";
 import { sumBy } from "lodash";
 import { ChevronDown, ChevronUp, EyeClosedIcon, EyeIcon } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -108,7 +108,7 @@ function PlaygroundBillListCard({
                   key={bill.id}
                   className={cn(
                     "hover:bg-muted/50 relative -mx-5 flex cursor-pointer items-center gap-3 px-5 py-3 transition-colors",
-                    isEqual(bill.date, payDate) &&
+                    isSameDay(bill.date, payDate) &&
                       "text-yellow-700 dark:text-yellow-500",
                     isExcluded && "opacity-40",
                   )}

--- a/src/lib/bill-utils.ts
+++ b/src/lib/bill-utils.ts
@@ -18,6 +18,59 @@ export function createPayRule(incomeProfile: IncomeProfile) {
   });
 }
 
+/**
+ * Monthly recurrences anchor on the day-of-month taken from `dtstart`. RRule's
+ * default is to SKIP months that lack that day — a bill on the 31st silently
+ * disappears in February, April, etc. Instead we clamp to the last day of short
+ * months (a "31st" bill lands on Feb 28, Apr 30, …) so it never vanishes. Days
+ * ≤ 28 exist in every month, so this matches RRule's output for them.
+ *
+ * Dates are built in UTC to stay in the same frame as the UTC-midnight `dtstart`
+ * the rest of the scheduler uses. `interval`/`until`/`count` mirror RRule:
+ * `count` counts occurrences from `dtstart`; `until` is inclusive.
+ */
+function monthlyOccurrencesInPeriod(
+  dtstart: Date,
+  interval: number,
+  until: Date | undefined,
+  count: number | undefined,
+  periodStart: Date,
+  periodEnd: Date,
+) {
+  const targetDay = dtstart.getUTCDate();
+  const startYear = dtstart.getUTCFullYear();
+  const startMonth = dtstart.getUTCMonth();
+  const step = Math.max(1, interval);
+
+  const occurrences: Date[] = [];
+  let emitted = 0;
+  // Occurrences increase monotonically, so we stop once past the window; the
+  // iteration cap is only a defensive backstop against pathological input.
+  for (let i = 0; i < 12_000; i++) {
+    if (count != null && emitted >= count) break;
+
+    const monthIndex = startMonth + i * step;
+    const year = startYear + Math.floor(monthIndex / 12);
+    const month = monthIndex % 12;
+    const lastDayOfMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    const occ = new Date(
+      Date.UTC(year, month, Math.min(targetDay, lastDayOfMonth)),
+    );
+
+    if (until != null && isAfter(occ, until)) break;
+    emitted++;
+
+    if (
+      (isAfter(occ, periodStart) || isEqual(occ, periodStart)) &&
+      isBefore(occ, periodEnd)
+    ) {
+      occurrences.push(occ);
+    }
+    if (!isBefore(occ, periodEnd)) break;
+  }
+  return occurrences;
+}
+
 export function computeBillsInPeriod(
   bills: BillEvent[],
   periodStart: Date,
@@ -37,23 +90,43 @@ export function computeBillsInPeriod(
       }
 
       const { recurrence } = bill;
+      const dtstart = recurrence.dtstart ?? periodStart;
 
-      const billRule = new RRule({
-        ...getFrequency(recurrence.type),
-        interval: recurrence.interval,
-        dtstart: recurrence.dtstart ?? periodStart,
-        bymonthday: recurrence.bymonthday,
-        until: recurrence.until,
-        count: recurrence.count,
-      });
-
-      const billDates = billRule
-        .between(periodStart, periodEnd, true)
-        .filter(
-          (date) =>
-            (isAfter(date, periodStart) || isEqual(date, periodStart)) &&
-            isBefore(date, periodEnd),
+      // Monthly bills with no explicit bymonthday use the clamping generator so
+      // a day missing from a short month falls on that month's last day instead
+      // of being skipped. Weekly/fortnightly (and any explicit bymonthday) keep
+      // using RRule.
+      let billDates: Date[];
+      if (
+        recurrence.type === "monthly" &&
+        (recurrence.bymonthday == null || recurrence.bymonthday.length === 0)
+      ) {
+        billDates = monthlyOccurrencesInPeriod(
+          dtstart,
+          recurrence.interval,
+          recurrence.until,
+          recurrence.count,
+          periodStart,
+          periodEnd,
         );
+      } else {
+        const billRule = new RRule({
+          ...getFrequency(recurrence.type),
+          interval: recurrence.interval,
+          dtstart,
+          bymonthday: recurrence.bymonthday,
+          until: recurrence.until,
+          count: recurrence.count,
+        });
+
+        billDates = billRule
+          .between(periodStart, periodEnd, true)
+          .filter(
+            (date) =>
+              (isAfter(date, periodStart) || isEqual(date, periodStart)) &&
+              isBefore(date, periodEnd),
+          );
+      }
 
       return billDates.map((date) => ({
         ...bill,


### PR DESCRIPTION
Three independent bill scheduling/date-correctness bugs surfaced during the review of #22 (and verified with adversarial cross-checking). Each is a focused commit.

## Fixes

**1. Next Bill card skipped a bill due today** — `financialSummaryCards.tsx`
`b.date >= new Date()` compared a midnight bill date against the current instant, so once the clock passed 00:00 a bill due *today* was dropped. Now compares on day granularity (`startOfDay`).

**2. "Due on payday" highlight never fired** — `billList.tsx`, `playgroundBillList.tsx`
`isEqual(bill.date, payDate)` needed exact-instant equality, but bill dates (UTC midnight) and pay-period boundaries (local midnight) are never the same instant. Now uses `isSameDay` (calendar-day match).

**3. Monthly bills on the 29th–31st vanished in short months** — `bill-utils.ts`
RRule's `MONTHLY` default skips months that lack the day (a "31st" bill produced no occurrence in Feb/Apr/Jun/Sep/Nov). Monthly bills (without an explicit `bymonthday`) now route through a clamping generator that lands the 29th–31st on the month's **last day** (Feb 28, Apr 30, …). Weekly/fortnightly keep using RRule.

## Verification
- `tsc --noEmit` clean; ESLint clean on all changed files.
- #1/#2 reproduced fixed under `Asia/Manila` (old `false` → new `true`).
- #3: clamping generator matches RRule **exactly** for days ≤28 across `interval`/`until`/`count` (36/36 checks → no regression); days 29/30/31 now yield 12 occurrences/yr (was 11/11/7). Clean distribution across 84 pay-period configs (no double-count/drop at boundaries).

## Notes
- **Behavior choice (#3):** month-end **clamp** (the common billing default) so bills never disappear. If `skip` (prior behavior) or roll-to-1st-of-next-month is preferred, it's localized to one generator in `bill-utils.ts`.
- **Not included:** issue #22 itself (the UTC/local day-shift) is still open — the durable fix is a larger UTC-naive-frame refactor, intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)