### PR TITLE
fix: handle date-only values in a UTC-naive frame (#22)

### DIFF
--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { formatDate, isSameDay, subDays } from "date-fns";
+import { isSameDay, subDays } from "date-fns";
 import { sumBy } from "lodash";
 import { EyeClosedIcon, EyeIcon, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BillModal } from "~/components/billModal";
 import { getPayPeriodsByCount } from "~/lib/bill-utils";
+import { formatUtcDate } from "~/lib/date-utils";
 import { UNGROUPED_COLOR, colorForOrder } from "~/lib/group-colors";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
@@ -101,7 +102,7 @@ function BillRowItem({
             {isDue && (
               <span className="mr-1 inline-block size-2 rounded-full bg-amber-400 dark:bg-amber-500 align-middle opacity-80" />
             )}
-            {formatDate(bill.date, "MMM d")}
+            {formatUtcDate(bill.date, "MMM d")}
           </div>
         )}
       </div>
@@ -170,8 +171,8 @@ function BillListCard({
     );
 
   const dateLabel = after
-    ? `${formatDate(payDate, "MMM d")} – ${formatDate(subDays(after, 1), "MMM d, yyyy")}`
-    : formatDate(payDate, "MMM d, yyyy");
+    ? `${formatUtcDate(payDate, "MMM d")} – ${formatUtcDate(subDays(after, 1), "MMM d, yyyy")}`
+    : formatUtcDate(payDate, "MMM d, yyyy");
 
   return (
     <div

--- a/src/components/billFormFields.tsx
+++ b/src/components/billFormFields.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { format } from "date-fns";
 import { useWatch, type UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import { api } from "~/trpc/react";
+import { formatUtcDate } from "~/lib/date-utils";
 import { colorForOrder } from "~/lib/group-colors";
 import {
   Form,
@@ -198,7 +198,7 @@ export function BillFormFields({
                       placeholder="Date"
                       {...field}
                       value={
-                        field.value ? format(field.value, "yyyy-MM-dd") : ""
+                        field.value ? formatUtcDate(field.value, "yyyy-MM-dd") : ""
                       }
                     />
                   </FormControl>
@@ -269,7 +269,7 @@ export function BillFormFields({
                       placeholder="Date Start"
                       {...field}
                       value={
-                        field.value ? format(field.value, "yyyy-MM-dd") : ""
+                        field.value ? formatUtcDate(field.value, "yyyy-MM-dd") : ""
                       }
                     />
                   </FormControl>
@@ -336,7 +336,7 @@ export function BillFormFields({
                           disabled={recurringEndsWith !== "until"}
                           value={
                             field.value
-                              ? format(field.value, "yyyy-MM-dd")
+                              ? formatUtcDate(field.value, "yyyy-MM-dd")
                               : ""
                           }
                         />

--- a/src/components/billViewMode.tsx
+++ b/src/components/billViewMode.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { format } from "date-fns";
 import { Calendar, Loader2, Repeat } from "lucide-react";
 import { toast } from "sonner";
+import { formatUtcDate } from "~/lib/date-utils";
 import { colorForOrder } from "~/lib/group-colors";
 import { api } from "~/trpc/react";
 import type { BillEvent } from "~/types";
@@ -136,7 +136,7 @@ export function BillViewMode({ bill, onEdit, onDelete }: BillViewModeProps) {
             <label className="text-muted-foreground text-sm">Due Date</label>
             <div className="flex items-center gap-2">
               <Calendar className="text-muted-foreground size-4" />
-              <p className="font-medium">{format(bill.date, "PPP")}</p>
+              <p className="font-medium">{formatUtcDate(bill.date, "PPP")}</p>
             </div>
           </div>
         )}
@@ -167,7 +167,7 @@ export function BillViewMode({ bill, onEdit, onDelete }: BillViewModeProps) {
                 <div className="flex items-center gap-2">
                   <Calendar className="text-muted-foreground size-4" />
                   <p className="font-medium">
-                    {format(bill.recurrence.dtstart, "PPP")}
+                    {formatUtcDate(bill.recurrence.dtstart, "PPP")}
                   </p>
                 </div>
               </div>
@@ -181,7 +181,7 @@ export function BillViewMode({ bill, onEdit, onDelete }: BillViewModeProps) {
                 <div className="flex items-center gap-2">
                   <Calendar className="text-muted-foreground size-4" />
                   <p className="font-medium">
-                    {format(bill.recurrence.until, "PPP")}
+                    {formatUtcDate(bill.recurrence.until, "PPP")}
                   </p>
                 </div>
               </div>

--- a/src/components/createIncomeProfileForm.tsx
+++ b/src/components/createIncomeProfileForm.tsx
@@ -22,14 +22,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
+import { utcDateOnlyToLocal } from "~/lib/date-utils";
 import { api } from "~/trpc/react";
 import { DatePicker } from "./datePicker";
 
 const CreateIncomeProfileFormValuesSchema = z.object({
   payFrequency: z.enum(["weekly", "fortnightly", "monthly"]),
-  startDate: z.coerce.date<Date>().refine((val) => !isFuture(val), {
-    message: "No future dates allowed",
-  }),
+  // startDate is canonical UTC midnight; compare its calendar day (not the raw
+  // instant) so picking "today" is never treated as future in +offset zones.
+  startDate: z.coerce
+    .date<Date>()
+    .refine((val) => !isFuture(utcDateOnlyToLocal(val)), {
+      message: "No future dates allowed",
+    }),
 });
 
 type CreateIncomeProfileFormValues = z.infer<

--- a/src/components/datePicker.tsx
+++ b/src/components/datePicker.tsx
@@ -3,6 +3,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { Calendar } from "./ui/calendar";
+import { localDateToUtcDateOnly, utcDateOnlyToLocal } from "~/lib/date-utils";
 
 export function DatePicker({
   value,
@@ -12,7 +13,11 @@ export function DatePicker({
   onChange?: (date?: Date) => void;
 }) {
   const [open, setOpen] = React.useState(false);
-  const [date, setDate] = React.useState<Date | undefined>(value);
+
+  // `value` is canonical UTC midnight; the Calendar works in local time, so we
+  // present the same calendar day as a local Date and convert the selection
+  // back to UTC midnight on the way out.
+  const selected = value ? utcDateOnlyToLocal(value) : undefined;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -21,18 +26,17 @@ export function DatePicker({
           variant="outline"
           className="text-muted-foreground hover:text-muted-foreground w-full justify-between bg-transparent font-normal hover:bg-transparent"
         >
-          {date ? date.toLocaleDateString() : "Select date"}
+          {selected ? selected.toLocaleDateString() : "Select date"}
           <ChevronDownIcon />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto overflow-hidden p-0" align="start">
         <Calendar
           mode="single"
-          selected={date}
+          selected={selected}
           captionLayout="dropdown"
           onSelect={(date) => {
-            setDate(date);
-            onChange?.(date);
+            onChange?.(date ? localDateToUtcDateOnly(date) : undefined);
             setOpen(false);
           }}
         />

--- a/src/components/editIncomeProfileDialog.tsx
+++ b/src/components/editIncomeProfileDialog.tsx
@@ -30,15 +30,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
+import { utcDateOnlyToLocal } from "~/lib/date-utils";
 import { api } from "~/trpc/react";
 import { DatePicker } from "./datePicker";
 import type { IncomeProfile } from "~/types";
 
 const EditIncomeProfileSchema = z.object({
   payFrequency: z.enum(["weekly", "fortnightly", "monthly"]),
-  startDate: z.coerce.date<Date>().refine((val) => !isFuture(val), {
-    message: "No future dates allowed",
-  }),
+  // startDate is canonical UTC midnight; compare its calendar day (not the raw
+  // instant) so picking "today" is never treated as future in +offset zones.
+  startDate: z.coerce
+    .date<Date>()
+    .refine((val) => !isFuture(utcDateOnlyToLocal(val)), {
+      message: "No future dates allowed",
+    }),
   amount: z.number().min(0, "Amount must be 0 or more").optional(),
 });
 

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -7,10 +7,15 @@ import {
   PiggyBank,
   Wallet,
 } from "lucide-react";
-import { formatDate, startOfDay } from "date-fns";
+import { startOfDay } from "date-fns";
 import { sumBy } from "lodash";
 import { Card, CardContent } from "~/components/ui/card";
 import { createPayRule, computeBillsInPeriod } from "~/lib/bill-utils";
+import {
+  formatUtcDate,
+  localDateToUtcDateOnly,
+  utcDateOnlyToLocal,
+} from "~/lib/date-utils";
 import type { BillEvent, IncomeProfile } from "~/types";
 
 function formatPHP(value: number) {
@@ -29,7 +34,7 @@ export function FinancialSummaryCards({
 }) {
   const { currentPeriodBills, nextBill } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
-    const currentPay = payRule.before(new Date(), true);
+    const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
     if (!currentPay) return { currentPeriodBills: [], nextBill: null };
 
     const nextPayDate = payRule.after(currentPay);
@@ -41,7 +46,9 @@ export function FinancialSummaryCards({
     // granularity: bill dates are at midnight, so `b.date >= new Date()` would
     // drop a bill due today once the wall clock passes midnight.
     const today = startOfDay(new Date());
-    const upcoming = periodBills.find((b) => b.date >= today);
+    const upcoming = periodBills.find(
+      (b) => utcDateOnlyToLocal(b.date) >= today,
+    );
 
     return { currentPeriodBills: periodBills, nextBill: upcoming ?? null };
   }, [incomeProfile, bills]);
@@ -73,7 +80,7 @@ export function FinancialSummaryCards({
       icon: CalendarClock,
       label: "Next Bill",
       value: nextBill?.title ?? "None",
-      subtitle: nextBill ? formatDate(nextBill.date, "MMM dd, yyyy") : "No upcoming bills",
+      subtitle: nextBill ? formatUtcDate(nextBill.date, "MMM dd, yyyy") : "No upcoming bills",
     },
   ];
 

--- a/src/components/incomeProfileSection.tsx
+++ b/src/components/incomeProfileSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { formatDate } from "date-fns";
 import { Pencil } from "lucide-react";
+import { formatUtcDate } from "~/lib/date-utils";
 import { Button } from "~/components/ui/button";
 import { EditIncomeProfileDialog } from "./editIncomeProfileDialog";
 import type { IncomeProfile } from "~/types";
@@ -30,7 +30,7 @@ export function IncomeProfileSection({
         <div>
           <span className="text-muted-foreground">Start Date: </span>
           <span className="font-medium">
-            {formatDate(incomeProfile.startDate, "MMM dd, yyyy")}
+            {formatUtcDate(incomeProfile.startDate, "MMM dd, yyyy")}
           </span>
         </div>
         <div>

--- a/src/components/playgroundBillList.tsx
+++ b/src/components/playgroundBillList.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { formatDate, isSameDay, subDays } from "date-fns";
+import { isSameDay, subDays } from "date-fns";
 import { sumBy } from "lodash";
 import { ChevronDown, ChevronUp, EyeClosedIcon, EyeIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { getBillsByPayPeriod } from "~/lib/bill-utils";
+import { formatUtcDate } from "~/lib/date-utils";
 import { cn } from "~/lib/utils";
 import type { BillEvent, IncomeProfile, PlaygroundBill } from "~/types";
 
@@ -77,8 +78,8 @@ function PlaygroundBillListCard({
       >
         <div>
           <div className="text-sm font-semibold">
-            {formatDate(payDate, "MMM d")}
-            {after && <> – {formatDate(subDays(after, 1), "MMM d, yyyy")}</>}
+            {formatUtcDate(payDate, "MMM d")}
+            {after && <> – {formatUtcDate(subDays(after, 1), "MMM d, yyyy")}</>}
           </div>
           <div className="text-muted-foreground mt-0.5 text-xs">
             {bills.length} {bills.length === 1 ? "bill" : "bills"}
@@ -143,7 +144,7 @@ function PlaygroundBillListCard({
                     </div>
                     {!isExcluded && (
                       <div className="text-muted-foreground text-xs">
-                        Due {formatDate(bill.date, "MMM d")}
+                        Due {formatUtcDate(bill.date, "MMM d")}
                       </div>
                     )}
                   </div>

--- a/src/components/playgroundBillModal.tsx
+++ b/src/components/playgroundBillModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { format } from "date-fns";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { formatUtcDate } from "~/lib/date-utils";
 import type { PlaygroundBill, PlaygroundBillData } from "~/types";
 import {
   BillFormFields,
@@ -69,7 +69,7 @@ function PlaygroundBillViewMode({
         {bill.type === "single" ? (
           <div>
             <p className="text-muted-foreground text-sm">Due Date</p>
-            <p className="font-medium">{format(bill.date, "MMMM d, yyyy")}</p>
+            <p className="font-medium">{formatUtcDate(bill.date, "MMMM d, yyyy")}</p>
           </div>
         ) : (
           <div>
@@ -81,7 +81,7 @@ function PlaygroundBillViewMode({
             </p>
             {bill.recurrence.dtstart && (
               <p className="text-muted-foreground text-sm">
-                Starting {format(bill.recurrence.dtstart, "MMMM d, yyyy")}
+                Starting {formatUtcDate(bill.recurrence.dtstart, "MMMM d, yyyy")}
               </p>
             )}
           </div>

--- a/src/lib/bill-utils.ts
+++ b/src/lib/bill-utils.ts
@@ -1,5 +1,6 @@
 import { addMonths, isAfter, isBefore, isEqual } from "date-fns";
 import { RRule } from "rrule";
+import { localDateToUtcDateOnly } from "./date-utils";
 import type { BillEvent, IncomeProfile } from "~/types";
 
 export function getFrequency(freq: "weekly" | "fortnightly" | "monthly") {
@@ -144,7 +145,7 @@ export function getBillsByPayPeriod(
   monthsAhead = 6,
 ) {
   const payRule = createPayRule(incomeProfile);
-  const currentPay = payRule.before(new Date(), true)!;
+  const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true)!;
   const paysUntilFuture = payRule.between(
     currentPay,
     addMonths(currentPay, monthsAhead),
@@ -170,7 +171,7 @@ export function getPayPeriodsByCount(
 ) {
   const payRule = createPayRule(incomeProfile);
   const payDates: Date[] = [];
-  let currentPay = payRule.before(new Date(), true)!;
+  let currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true)!;
   for (let i = 0; i < count; i++) {
     payDates.push(currentPay);
     currentPay = payRule.after(currentPay)!;

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,60 @@
+import { format } from "date-fns";
+
+/**
+ * Date-only values in this app (bill `date`/`dtstart`/`until`, income
+ * `startDate`, and the pay-period boundaries derived from them) are stored as
+ * `Date` instants but represent a calendar *day*, with no meaningful time.
+ *
+ * The canonical representation is **UTC midnight** (`YYYY-MM-DDT00:00:00Z`):
+ * - `rrule` schedules off a Date's UTC fields, so UTC-midnight anchors produce
+ *   occurrences on the intended day-of-month/weekday in every timezone.
+ * - Bill dates already land here (`z.coerce.date()` parses `"yyyy-MM-dd"` as
+ *   UTC midnight). Income dates (from the `Calendar`) are local midnight and
+ *   must be converted — see `localDateToUtcDateOnly` and the migration.
+ *
+ * Render and compare these values with the helpers below so the calendar day is
+ * stable in every timezone (date-fns `format` would otherwise shift the day in
+ * non-UTC zones).
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Convert a local-midnight `Date` (what the `Calendar`/`DatePicker` produces) to
+ * UTC midnight of the **same calendar day**, exactly, in any timezone.
+ */
+export function localDateToUtcDateOnly(local: Date): Date {
+  return new Date(
+    Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()),
+  );
+}
+
+/**
+ * Reinterpret a canonical (UTC-midnight) value's calendar day as a local `Date`,
+ * so date-fns `format` and day-granularity comparisons are timezone-independent.
+ */
+export function utcDateOnlyToLocal(utc: Date): Date {
+  return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate());
+}
+
+/** Format a canonical (UTC-midnight) value by its calendar day, timezone-stably. */
+export function formatUtcDate(date: Date, formatStr: string): string {
+  return format(utcDateOnlyToLocal(date), formatStr);
+}
+
+/**
+ * Round an arbitrary instant to the nearest UTC midnight. Used to canonicalize
+ * legacy income rows that were stored at *local* midnight (the old Calendar)
+ * when read/written, without a data migration. Already-canonical (UTC-midnight)
+ * values are unchanged (idempotent).
+ *
+ * Limitation: the original timezone can't be recovered from a bare instant, so
+ * rounding only recovers the intended calendar day for client UTC offsets in
+ * **(−12h, +12h]**. Offsets beyond +12h (NZ in NZDT = +13, Samoa/Tonga +13,
+ * Kiribati +14, Chatham +13:45) and exactly −12h round to the adjacent day.
+ * Those legacy rows self-correct the next time the profile is saved, since the
+ * picker now writes exact UTC midnight via `localDateToUtcDateOnly`.
+ */
+export function roundToUtcDateOnly(date: Date): Date {
+  return new Date(Math.round(date.getTime() / MS_PER_DAY) * MS_PER_DAY);
+}

--- a/src/server/api/routers/income.ts
+++ b/src/server/api/routers/income.ts
@@ -1,6 +1,7 @@
 import { ObjectId } from "mongodb";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import type { IncomeProfile } from "~/types";
+import { roundToUtcDateOnly } from "~/lib/date-utils";
 import { z } from "zod";
 
 export const incomeRouter = createTRPCRouter({
@@ -9,7 +10,15 @@ export const incomeRouter = createTRPCRouter({
       .collection<IncomeProfile>("income_profiles")
       .findOne({ userId: new ObjectId(ctx.session.user.id) });
 
-    return incomeProfile;
+    if (!incomeProfile) return incomeProfile;
+
+    // Heal legacy rows stored at local midnight to the canonical UTC-midnight
+    // date-only form so scheduling/rendering is timezone-stable. Idempotent for
+    // already-canonical rows.
+    return {
+      ...incomeProfile,
+      startDate: roundToUtcDateOnly(incomeProfile.startDate),
+    };
   }),
 
   createIncomeProfile: protectedProcedure
@@ -25,7 +34,7 @@ export const incomeRouter = createTRPCRouter({
       const incomeProfile = {
         userId: new ObjectId(ctx.session.user.id),
         payFrequency,
-        startDate,
+        startDate: roundToUtcDateOnly(startDate),
       };
 
       await ctx.db
@@ -46,7 +55,7 @@ export const incomeRouter = createTRPCRouter({
       if (input.payFrequency !== undefined)
         updateFields.payFrequency = input.payFrequency;
       if (input.startDate !== undefined)
-        updateFields.startDate = input.startDate;
+        updateFields.startDate = roundToUtcDateOnly(input.startDate);
       if (input.amount !== undefined) updateFields.amount = input.amount;
 
       await ctx.db


### PR DESCRIPTION
Closes #22.

## Problem
`rrule` schedules off a `Date`'s **UTC** fields, but `date-fns` `format` renders in **local** time. The app mixed frames — bill dates at UTC midnight (`z.coerce.date` on `"yyyy-MM-dd"`), income `startDate` at local midnight (the `Calendar`) — so in non-UTC timezones bills rendered and landed in the wrong day / wrong pay period.

## Fix — one UTC-naive frame
Every date-only value (bill `date`/`dtstart`/`until`, income `startDate`, pay-period boundaries) is canonical **UTC midnight**, and is rendered/compared by its UTC calendar day.

- **`src/lib/date-utils.ts`** (new): `localDateToUtcDateOnly`, `utcDateOnlyToLocal`, `formatUtcDate`, `roundToUtcDateOnly`.
- **Income** (`datePicker.tsx`, `income.ts`, both income forms): picker emits canonical UTC midnight; the router normalizes `startDate` on **read and write**, so legacy local-midnight rows **heal transparently — no data migration**. The "no future dates" check compares the calendar day.
- **Rendering** (7 sites): switched to `formatUtcDate`; the "upcoming bill" and current-pay-period selections compare on the local calendar day.
- `bill-utils` scheduling frame is unchanged (bills were already UTC midnight; pay boundaries become UTC midnight once income is normalized).

## Verification
- `tsc` + ESLint clean.
- Cross-tz harness (Manila / New York / UTC / Auckland): income, bills, **monthly-on-the-1st** (the case an earlier attempt regressed), and weekly weekday render the **same correct day everywhere**; pay-period assignment identical across tz.
- End-to-end dashboard render is **byte-identical to the pre-fix baseline in Asia/Manila (no regression)** while New York now shows the picked day instead of a day early.

## Adversarial review
A multi-agent review (4 dimensions × 3-skeptic verification) ran against this change; all confirmed findings are fixed in this PR:
- **Pay-period boundary** flipped at local 08:00 (UTC+8) instead of midnight — fixed (`before(localDateToUtcDateOnly(now))`).
- **`isFuture` refine** rejected "today" before 08:00 (UTC+8) — fixed (compare calendar day).
- **`roundToUtcDateOnly`** can't recover the day for offsets **beyond +12h** (NZ summer, Samoa, Kiribati) from a bare instant — an inherent limit, now documented; those legacy rows self-heal on next save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)