### PR TITLE
fix: date selection crash — keep date-only form state a Date

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verify
+description: Build/launch/drive recipe for verifying changes in the running Remind Me Bills app.
+---
+
+# Verify: Remind Me Bills
+
+## Launch
+
+```bash
+pnpm dev --port <port>   # Turbopack; up in ~7s. Needs MONGODB_URI etc. in .env
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/   # 200 when ready
+```
+
+## Getting a session (no OAuth needed)
+
+Protected routes (`/dashboard`, `/bills/*`, `/playground`) 307-redirect to `/`
+without a session. On the landing page click **"Try as Guest"** — anonymous
+Better Auth sign-in, cookie-based, works headlessly via Playwright.
+
+## Flows worth driving
+
+- **Income profile** (first-run gate): `/dashboard` shows the setup form until
+  a profile exists — pay frequency select + `DatePicker` (Calendar popover).
+  The playground refuses to load without it.
+- **Bill create**: `/bills/create` — `BillFormFields` ("Once" date, "Repeating"
+  dtstart/until `DateInput`s). Until input stays disabled until its radio is
+  picked.
+- **Bill edit**: click a bill row on `/dashboard` → details dialog → Edit —
+  same `BillFormFields` seeded from server `Date`s.
+
+## Gotchas
+
+- Date fields are native `<input type="date">` — Playwright `fill` with
+  `"yyyy-MM-dd"` works.
+- Guest data persists in MongoDB per anonymous user; each fresh browser
+  context starts clean.
+- Expected noise: Better Auth "Base URL could not be determined" WARNs when
+  `BETTER_AUTH_URL` is unset locally; Radix "Missing Description for
+  DialogContent" browser warnings. Both pre-existing.

--- a/src/components/billFormFields.tsx
+++ b/src/components/billFormFields.tsx
@@ -3,8 +3,8 @@
 import { useWatch, type UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import { api } from "~/trpc/react";
-import { formatUtcDate } from "~/lib/date-utils";
 import { colorForOrder } from "~/lib/group-colors";
+import { DateInput } from "./dateInput";
 import {
   Form,
   FormControl,
@@ -193,14 +193,7 @@ export function BillFormFields({
                 <FormItem className="flex flex-col">
                   <FormLabel>Date</FormLabel>
                   <FormControl>
-                    <Input
-                      type="date"
-                      placeholder="Date"
-                      {...field}
-                      value={
-                        field.value ? formatUtcDate(field.value, "yyyy-MM-dd") : ""
-                      }
-                    />
+                    <DateInput placeholder="Date" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -264,14 +257,7 @@ export function BillFormFields({
                 <FormItem>
                   <FormLabel>Date Start</FormLabel>
                   <FormControl>
-                    <Input
-                      type="date"
-                      placeholder="Date Start"
-                      {...field}
-                      value={
-                        field.value ? formatUtcDate(field.value, "yyyy-MM-dd") : ""
-                      }
-                    />
+                    <DateInput placeholder="Date Start" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -329,16 +315,10 @@ export function BillFormFields({
                         Until
                       </FormLabel>
                       <FormControl>
-                        <Input
-                          type="date"
+                        <DateInput
                           placeholder="Until"
                           {...field}
                           disabled={recurringEndsWith !== "until"}
-                          value={
-                            field.value
-                              ? formatUtcDate(field.value, "yyyy-MM-dd")
-                              : ""
-                          }
                         />
                       </FormControl>
                       <FormMessage />

--- a/src/components/dateInput.tsx
+++ b/src/components/dateInput.tsx
@@ -1,0 +1,30 @@
+import type React from "react";
+import { dateInputToUtcDateOnly, formatUtcDate } from "~/lib/date-utils";
+import { Input } from "./ui/input";
+
+/**
+ * Native `<input type="date">` that speaks canonical UTC-midnight `Date`s
+ * (the sibling of `DatePicker`, which does the same for the popover Calendar).
+ *
+ * The DOM input's currency is a `"yyyy-MM-dd"` string; this owns both
+ * directions of that conversion so form state never holds the raw string.
+ * Spreading a react-hook-form `field` here is safe — the default RHF
+ * `onChange` (which would store the string) is overridden by this contract.
+ */
+export function DateInput({
+  value,
+  onChange,
+  ...props
+}: Omit<React.ComponentProps<typeof Input>, "type" | "value" | "onChange"> & {
+  value?: Date;
+  onChange?: (date?: Date) => void;
+}) {
+  return (
+    <Input
+      type="date"
+      {...props}
+      value={value ? formatUtcDate(value, "yyyy-MM-dd") : ""}
+      onChange={(e) => onChange?.(dateInputToUtcDateOnly(e.target.value))}
+    />
+  );
+}

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -43,6 +43,20 @@ export function formatUtcDate(date: Date, formatStr: string): string {
 }
 
 /**
+ * Parse a native `<input type="date">` value (`"yyyy-MM-dd"`, or `""` when
+ * cleared) into a canonical UTC-midnight `Date`, or `undefined` when empty or
+ * invalid. The inverse of rendering with `formatUtcDate(value, "yyyy-MM-dd")`:
+ * keeps date-only form state a `Date` (not the input's raw string) so the
+ * display formatter and the `z.coerce.date()` schema agree. `new Date("yyyy-MM-dd")`
+ * parses as UTC midnight, which is exactly the canonical representation.
+ */
+export function dateInputToUtcDateOnly(value: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/**
  * Round an arbitrary instant to the nearest UTC midnight. Used to canonicalize
  * legacy income rows that were stored at *local* midnight (the old Calendar)
  * when read/written, without a data migration. Already-canonical (UTC-midnight)


### PR DESCRIPTION
## Problem

Selecting a date in the bill form crashed the page:

```
Uncaught TypeError: e.getUTCFullYear is not a function
```

## Root cause

React Hook Form's default `onChange` for a native `<input type="date">` stores the raw `"yyyy-MM-dd"` string in form state, while the field is typed (and rendered) as a `Date`. The state has held strings after every user edit since the form was written — date-fns `format()` silently coerced them, which masked the mismatch. #24 switched the display path to `formatUtcDate`, which calls `.getUTCFullYear()` directly, so the first date selection after that crashed on re-render.

The underlying trap: the string↔Date boundary needs two conversions that must agree (`value` out, `onChange` in), and they were inlined separately at each of the three date fields — easy to half-wire, which is exactly what happened.

## Fix

- New `DateInput` component — the native-input sibling of `DatePicker`. It owns both directions of the conversion, so spreading a RHF `field` into it can no longer half-wire the adapter.
- New `dateInputToUtcDateOnly()` in `date-utils` — the documented inverse of `formatUtcDate(v, "yyyy-MM-dd")`, producing the canonical UTC-midnight `Date`.
- The three inline adapters in `billFormFields` collapse to `<DateInput {...field} />` (net −20 lines).
- Also adds a project verify skill (`.claude/skills/verify/SKILL.md`) with the launch/drive recipe used to verify this.

## Verification

Drove the running app headlessly (guest session):
- Reproduced path: filled the "Once" date → no crash, value renders, zero console errors
- Cleared the date → field empties cleanly (`undefined` path)
- Created a bill → lands on the dashboard as Jul 15 in the right pay period (full RHF → Zod → tRPC → MongoDB → SuperJSON round trip)
- Edit modal pre-fills from server `Date`s; converted the bill to repeating with `dtstart` + `until` → occurrences appear Jul–Oct and stop after the until date

Note: commits are unsigned (1Password signing unavailable during the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)