### PR TITLE
feat: extend "quiet ledger" design language across the app (consistency pass 1)

### DIFF
--- a/src/components/authenticatedLayout.tsx
+++ b/src/components/authenticatedLayout.tsx
@@ -14,6 +14,7 @@ import {
 
 import { useQueryClient } from "@tanstack/react-query";
 import { authClient } from "~/lib/auth-client";
+import { cn } from "~/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Button } from "./ui/button";
 import {
@@ -32,6 +33,17 @@ import {
   SheetTrigger,
 } from "./ui/sheet";
 
+function Wordmark() {
+  return (
+    <span className="text-ledger-ink font-display flex items-center gap-2 text-lg font-medium">
+      <span className="bg-ledger-ink text-ledger-paper flex size-7 items-center justify-center rounded-lg">
+        <Receipt className="size-4" />
+      </span>
+      Remind Me Bills
+    </span>
+  );
+}
+
 function UserNav() {
   const router = useRouter();
   const { data: session } = authClient.useSession();
@@ -40,7 +52,7 @@ function UserNav() {
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-muted-foreground hidden text-sm sm:inline">
+      <span className="text-ledger-muted hidden text-sm sm:inline">
         {session?.user?.name}
       </span>
       <DropdownMenu>
@@ -96,29 +108,32 @@ export function AuthenticatedLayout({ children }: PropsWithChildren) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
-    <div className="flex min-h-svh flex-col">
-      <header className="bg-background/80 sticky top-0 z-50 border-b backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+    <div className="bg-ledger-paper text-ledger-ink font-sans flex min-h-svh flex-col antialiased">
+      <header className="border-ledger-line bg-ledger-paper/80 sticky top-0 z-50 w-full border-b backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
           <div className="flex items-center gap-6">
-            <Link href="/" className="flex items-center gap-2 font-semibold">
-              <Receipt className="size-5" />
-              <span>Remind Me Bills</span>
+            <Link href="/">
+              <Wordmark />
             </Link>
             <nav className="hidden items-center gap-4 sm:flex">
-              {navLinks.map(({ href, label, icon: Icon }) => (
-                <Link
-                  key={href}
-                  href={href}
-                  className={`flex items-center gap-1 text-sm font-medium transition-colors hover:text-foreground ${
-                    pathname === href
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  {Icon && <Icon className="size-3.5" />}
-                  {label}
-                </Link>
-              ))}
+              {navLinks.map(({ href, label, icon: Icon }) => {
+                const isActive = pathname === href;
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    className={cn(
+                      "flex items-center gap-1.5 text-sm font-medium transition-colors",
+                      isActive
+                        ? "text-ledger-accent-strong"
+                        : "text-ledger-muted hover:text-ledger-ink",
+                    )}
+                  >
+                    <Icon className="size-3.5" />
+                    {label}
+                  </Link>
+                );
+              })}
             </nav>
           </div>
           <div className="flex items-center gap-2">
@@ -135,27 +150,32 @@ export function AuthenticatedLayout({ children }: PropsWithChildren) {
               </SheetTrigger>
               <SheetContent side="left">
                 <SheetHeader>
-                  <SheetTitle className="flex items-center gap-2">
-                    <Receipt className="size-5" />
-                    Remind Me Bills
+                  <SheetTitle asChild>
+                    <span>
+                      <Wordmark />
+                    </span>
                   </SheetTitle>
                 </SheetHeader>
                 <nav className="flex flex-col gap-1 px-6">
-                  {navLinks.map(({ href, label, icon: Icon }) => (
-                    <Link
-                      key={href}
-                      href={href}
-                      onClick={() => setMobileMenuOpen(false)}
-                      className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground ${
-                        pathname === href
-                          ? "bg-accent text-accent-foreground"
-                          : "text-muted-foreground"
-                      }`}
-                    >
-                      {Icon && <Icon className="size-4" />}
-                      {label}
-                    </Link>
-                  ))}
+                  {navLinks.map(({ href, label, icon: Icon }) => {
+                    const isActive = pathname === href;
+                    return (
+                      <Link
+                        key={href}
+                        href={href}
+                        onClick={() => setMobileMenuOpen(false)}
+                        className={cn(
+                          "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                          isActive
+                            ? "bg-ledger-accent-soft text-ledger-accent-strong"
+                            : "text-ledger-muted hover:bg-ledger-accent-soft/50 hover:text-ledger-ink",
+                        )}
+                      >
+                        <Icon className="size-4" />
+                        {label}
+                      </Link>
+                    );
+                  })}
                 </nav>
               </SheetContent>
             </Sheet>
@@ -164,12 +184,13 @@ export function AuthenticatedLayout({ children }: PropsWithChildren) {
         </div>
       </header>
       <main className="flex-1">{children}</main>
-      <footer className="border-t px-4 py-6">
-        <div className="mx-auto flex max-w-5xl items-center justify-center gap-2 text-sm">
-          <Receipt className="text-muted-foreground size-4" />
-          <span className="text-muted-foreground">
-            Remind Me Bills &copy; {new Date().getFullYear()}
-          </span>
+      <footer className="border-ledger-line border-t px-4 py-8">
+        <div className="text-ledger-muted mx-auto flex max-w-5xl flex-col items-center justify-between gap-3 text-sm sm:flex-row">
+          <div className="flex items-center gap-2">
+            <Receipt className="size-4" />
+            <span>Remind Me Bills</span>
+          </div>
+          <span>&copy; {new Date().getFullYear()} Remind Me Bills</span>
         </div>
       </footer>
     </div>

--- a/src/components/dashboardPage.tsx
+++ b/src/components/dashboardPage.tsx
@@ -70,9 +70,13 @@ function NoIncomeProfileState() {
   return (
     <div className="mx-auto max-w-5xl p-4 sm:p-6">
       <div className="flex flex-col items-center justify-center py-16">
-        <Receipt className="text-muted-foreground mb-4 size-12" />
-        <h2 className="text-2xl font-bold">Welcome to Remind Me Bills</h2>
-        <p className="text-muted-foreground mt-1 text-center">
+        <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-4 flex size-12 items-center justify-center rounded-2xl">
+          <Receipt className="size-6" />
+        </span>
+        <h2 className="text-ledger-ink font-display text-2xl">
+          Welcome to Remind Me Bills
+        </h2>
+        <p className="text-ledger-muted mt-1 text-center">
           Set up your income profile to get started tracking your bills.
         </p>
         <div className="mt-8 w-full max-w-md">
@@ -85,10 +89,12 @@ function NoIncomeProfileState() {
 
 function NoBillsState() {
   return (
-    <div className="flex flex-col items-center rounded-lg border border-dashed py-12">
-      <FileText className="text-muted-foreground mb-3 size-10" />
-      <h3 className="text-lg font-medium">No bills yet</h3>
-      <p className="text-muted-foreground mt-1 text-sm">
+    <div className="border-ledger-line flex flex-col items-center rounded-lg border border-dashed py-12">
+      <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-3 flex size-11 items-center justify-center rounded-2xl">
+        <FileText className="size-5" />
+      </span>
+      <h3 className="text-ledger-ink font-display text-lg">No bills yet</h3>
+      <p className="text-ledger-muted mt-1 text-sm">
         Add your first bill to start tracking your expenses.
       </p>
       <Button asChild className="mt-4">
@@ -135,7 +141,9 @@ export function DashboardPage() {
         />
         <IncomeProfileSection incomeProfile={incomeProfile} />
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Bills by Pay Period</h2>
+          <h2 className="text-ledger-ink font-display text-xl">
+            Bills by Pay Period
+          </h2>
           <Button asChild size="sm">
             <Link href="/bills/create">
               New Bill <CalendarPlus className="ml-1 size-4" />

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -6,10 +6,12 @@ import {
   FileText,
   PiggyBank,
   Wallet,
+  type LucideIcon,
 } from "lucide-react";
 import { startOfDay } from "date-fns";
 import { sumBy } from "lodash";
 import { Card, CardContent } from "~/components/ui/card";
+import { cn } from "~/lib/utils";
 import { createPayRule, computeBillsInPeriod } from "~/lib/bill-utils";
 import {
   formatUtcDate,
@@ -24,6 +26,23 @@ function formatPHP(value: number) {
     currency: "PHP",
   });
 }
+
+// Color the balance by sign so it agrees with the bill list's money semantics:
+// teal reads as "ahead", rose as "short".
+function balanceToneClass(balance: number) {
+  if (balance > 0) return "text-teal-700 dark:text-teal-300";
+  if (balance < 0) return "text-rose-600 dark:text-rose-400";
+  return "text-ledger-ink";
+}
+
+type SummaryCard = {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  subtitle: string;
+  mono: boolean;
+  valueClassName?: string;
+};
 
 export function FinancialSummaryCards({
   incomeProfile,
@@ -57,30 +76,35 @@ export function FinancialSummaryCards({
   const totalBillAmount = sumBy(currentPeriodBills, (b) => b.amount ?? 0);
   const balance = income - totalBillAmount;
 
-  const cards = [
+  const cards: SummaryCard[] = [
     {
       icon: Wallet,
       label: "Income",
       value: income > 0 ? formatPHP(income) : "Not set",
       subtitle: `Per ${incomeProfile.payFrequency === "fortnightly" ? "fortnight" : incomeProfile.payFrequency === "weekly" ? "week" : "month"}`,
+      mono: true,
     },
     {
       icon: FileText,
       label: "Total Bills",
       value: bills.length.toString(),
       subtitle: "Active bills",
+      mono: true,
     },
     {
       icon: PiggyBank,
       label: "Balance",
       value: formatPHP(balance),
       subtitle: "This period",
+      mono: true,
+      valueClassName: balanceToneClass(balance),
     },
     {
       icon: CalendarClock,
       label: "Next Bill",
       value: nextBill?.title ?? "None",
       subtitle: nextBill ? formatUtcDate(nextBill.date, "MMM dd, yyyy") : "No upcoming bills",
+      mono: false,
     },
   ];
 
@@ -90,11 +114,19 @@ export function FinancialSummaryCards({
         <Card key={card.label}>
           <CardContent className="flex flex-col gap-1 p-4">
             <div className="flex items-center gap-2">
-              <card.icon className="text-muted-foreground size-4" />
-              <span className="text-muted-foreground text-sm">{card.label}</span>
+              <card.icon className="text-ledger-muted size-4" />
+              <span className="text-ledger-muted text-sm">{card.label}</span>
             </div>
-            <span className="truncate text-xl font-semibold">{card.value}</span>
-            <span className="text-muted-foreground text-xs">{card.subtitle}</span>
+            <span
+              className={cn(
+                "text-ledger-ink truncate text-xl font-semibold",
+                card.mono && "font-mono tabular-nums",
+                card.valueClassName,
+              )}
+            >
+              {card.value}
+            </span>
+            <span className="text-ledger-muted text-xs">{card.subtitle}</span>
           </CardContent>
         </Card>
       ))}

--- a/src/components/homePage.tsx
+++ b/src/components/homePage.tsx
@@ -105,15 +105,15 @@ type UpcomingBill = {
 // product's actual value shown rather than described. Amounts are numbers so
 // the total below stays a single source of truth.
 const upcomingBills: UpcomingBill[] = [
-  { name: "Rent", category: "Housing", due: "Jul 5", amount: 1450 },
-  { name: "Spotify", category: "Subscription", due: "Jul 9", amount: 11.99 },
-  { name: "Water", category: "Utilities", due: "Jul 14", amount: 62 },
-  { name: "Electric", category: "Utilities", due: "Jul 22", amount: 88.4 },
+  { name: "Rent", category: "Housing", due: "Jul 5", amount: 15000 },
+  { name: "Spotify", category: "Subscription", due: "Jul 9", amount: 149 },
+  { name: "Water", category: "Utilities", due: "Jul 14", amount: 640 },
+  { name: "Electric", category: "Utilities", due: "Jul 22", amount: 2300 },
 ];
 
-const currency = new Intl.NumberFormat("en-US", {
+const currency = new Intl.NumberFormat("en-PH", {
   style: "currency",
-  currency: "USD",
+  currency: "PHP",
 });
 
 const totalDue = upcomingBills.reduce((sum, bill) => sum + bill.amount, 0);

--- a/src/components/playgroundStartScreen.tsx
+++ b/src/components/playgroundStartScreen.tsx
@@ -33,20 +33,24 @@ export function PlaygroundStartScreen({
 
   return (
     <div className="flex flex-col items-center justify-center py-16">
-      <FlaskConical className="text-muted-foreground mb-4 size-12" />
-      <h1 className="text-2xl font-bold">Financial Playground</h1>
-      <p className="text-muted-foreground mt-2 max-w-md text-center">
+      <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-4 flex size-12 items-center justify-center rounded-2xl">
+        <FlaskConical className="size-6" />
+      </span>
+      <h1 className="text-ledger-ink font-display text-3xl">
+        Financial Playground
+      </h1>
+      <p className="text-ledger-muted mt-2 max-w-md text-center">
         Experiment with &quot;what-if&quot; scenarios. Add hypothetical bills to
         see how they&apos;d affect your budget. Nothing is saved.
       </p>
 
       <div className="mt-8 grid w-full max-w-lg gap-4 sm:grid-cols-2">
         <Card
-          className="cursor-pointer transition-colors hover:border-primary"
+          className="hover:border-ledger-accent cursor-pointer transition-colors"
           onClick={handleStartFresh}
         >
           <CardHeader className="pb-2">
-            <FileText className="text-primary mb-2 size-8" />
+            <FileText className="text-ledger-accent-strong mb-2 size-8" />
             <CardTitle className="text-lg">Start Fresh</CardTitle>
           </CardHeader>
           <CardContent>
@@ -61,12 +65,12 @@ export function PlaygroundStartScreen({
             "transition-colors",
             isBillsLoading
               ? "cursor-not-allowed opacity-50"
-              : "cursor-pointer hover:border-primary",
+              : "hover:border-ledger-accent cursor-pointer",
           )}
           onClick={isBillsLoading ? undefined : handleCloneBills}
         >
           <CardHeader className="pb-2">
-            <Copy className="text-primary mb-2 size-8" />
+            <Copy className="text-ledger-accent-strong mb-2 size-8" />
             <CardTitle className="text-lg">Clone My Bills</CardTitle>
           </CardHeader>
           <CardContent>


### PR DESCRIPTION
## Summary

**PR 1 of the UI consistency pass** — brings the signed-in surfaces in line with the redesigned landing (#25) so the whole app reads as one system. Per the agreed direction: unify on the **emerald "quiet ledger"** language (cool paper, Fraunces headings, mono figures, emerald as the single accent), while **keeping teal/rose for +/− balance** because color there encodes real meaning. Primary buttons stay **ink**, matching the shipped landing.

No new tokens were needed — the `--color-ledger-*` / `font-display` / `font-mono` utilities added in #25 are global; this PR just applies them.

### Changes
- **App shell (`authenticatedLayout.tsx`)** — highest leverage, wraps every signed-in page: ink-square + Fraunces wordmark, cool-paper surfaces, **emerald active-nav** state (desktop + mobile sheet), and a footer matching the landing.
- **`financialSummaryCards.tsx`** — figures now `font-mono tabular-nums`; **Balance** colored by sign (teal ahead / rose short) via a small `balanceToneClass` helper, agreeing with `billList`'s money semantics.
- **`playgroundStartScreen.tsx`** — Fraunces heading, emerald-soft icon mark, emerald card accents/hover.
- **Dashboard empty + welcome states (`dashboardPage.tsx`)** — Fraunces headings, emerald icon marks; "Bills by Pay Period" heading to Fraunces.
- **Landing hero mock (`homePage.tsx`)** — switched from **$ USD → ₱ PHP** (with plausible PH amounts) to match the app's real currency.

### Test plan
- [x] `pnpm typecheck` — passes
- [x] `eslint` (5 files) — exit 0
- [x] `prettier --write` — formatted
- [x] Rendered locally via `next dev` and **screenshot-verified** each surface: landing (₱ currency + derived total ₱18,089.00), app shell/nav/footer, dashboard summary cards (mono) + empty state, and the playground start screen

### Notes
- Balance teal/rose wasn't exercised with live income+bills in the screenshot pass (guest balance was ₱0.00 → neutral), but it mirrors `billList`'s exact classes.
- Follow-ups from the plan: **PR 2** = `billList` amber→emerald harmonization; **PR 3** = forms/modals/`groupManager` long-tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)