### PR TITLE
feat: extend ledger design language to forms, modals & playground (consistency pass 3)

### DIFF
--- a/src/components/createBillForm.tsx
+++ b/src/components/createBillForm.tsx
@@ -6,7 +6,11 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { api } from "~/trpc/react";
-import { BillFormFields, BillFormValuesSchema, type BillFormValues } from "./billFormFields";
+import {
+  BillFormFields,
+  BillFormValuesSchema,
+  type BillFormValues,
+} from "./billFormFields";
 import { Button } from "./ui/button";
 import {
   Card,
@@ -53,7 +57,7 @@ export function CreateBillForm() {
   return (
     <Card className="w-full max-w-lg">
       <CardHeader>
-        <CardTitle>Create a new bill</CardTitle>
+        <CardTitle className="font-display">Create a new bill</CardTitle>
         <CardDescription>
           Fill in the details of the bill you want to create.
         </CardDescription>

--- a/src/components/createIncomeProfileForm.tsx
+++ b/src/components/createIncomeProfileForm.tsx
@@ -115,7 +115,9 @@ export function CreateIncomeProfileForm() {
 export function IncomeProfileSetup() {
   return (
     <div className="w-full space-y-6 rounded-lg border p-6 shadow-md">
-      <h2 className="text-2xl font-bold">Setup Income Profile</h2>
+      <h2 className="text-ledger-ink font-display text-2xl">
+        Setup Income Profile
+      </h2>
       <CreateIncomeProfileForm />
     </div>
   );

--- a/src/components/groupManager.tsx
+++ b/src/components/groupManager.tsx
@@ -290,7 +290,7 @@ export function GroupManager() {
     <AuthenticatedLayout>
       <div className="mx-auto max-w-3xl space-y-6 p-4 sm:p-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">Groups</h1>
+          <h1 className="text-ledger-ink font-display text-2xl">Groups</h1>
           <Button onClick={() => setCreateOpen(true)}>
             <Plus className="mr-1 size-4" />
             New group

--- a/src/components/playgroundBillList.tsx
+++ b/src/components/playgroundBillList.tsx
@@ -65,7 +65,7 @@ function PlaygroundBillListCard({
       className={cn(
         "flex flex-col overflow-hidden rounded-xl border",
         isCurrent
-          ? "ring-primary/20 border-primary/50 ring-2"
+          ? "ring-ledger-accent/40 border-ledger-accent/50 ring-2"
           : "border-border",
       )}
     >
@@ -73,11 +73,11 @@ function PlaygroundBillListCard({
       <div
         className={cn(
           "flex items-center justify-between px-5 py-3.5",
-          isCurrent ? "bg-primary/5" : "bg-muted/30",
+          isCurrent ? "bg-ledger-accent-soft/40" : "bg-muted/30",
         )}
       >
         <div>
-          <div className="text-sm font-semibold">
+          <div className="font-mono text-sm font-semibold tabular-nums">
             {formatUtcDate(payDate, "MMM d")}
             {after && <> – {formatUtcDate(subDays(after, 1), "MMM d, yyyy")}</>}
           </div>
@@ -86,7 +86,7 @@ function PlaygroundBillListCard({
           </div>
         </div>
         {isCurrent && (
-          <span className="bg-primary text-primary-foreground rounded-full px-2.5 py-0.5 text-[11px] font-medium">
+          <span className="bg-ledger-accent-soft text-ledger-accent-strong rounded-full px-2.5 py-0.5 text-[11px] font-medium">
             Current
           </span>
         )}
@@ -110,7 +110,7 @@ function PlaygroundBillListCard({
                   className={cn(
                     "hover:bg-muted/50 relative -mx-5 flex cursor-pointer items-center gap-3 px-5 py-3 transition-colors",
                     isSameDay(bill.date, payDate) &&
-                      "text-yellow-700 dark:text-yellow-500",
+                      "text-ledger-accent-strong dark:text-ledger-accent",
                     isExcluded && "opacity-40",
                   )}
                   onClick={() => onBillClick(bill.id)}
@@ -149,7 +149,7 @@ function PlaygroundBillListCard({
                     )}
                   </div>
                   {!isExcluded && (
-                    <span className="shrink-0 text-sm font-medium tabular-nums">
+                    <span className="shrink-0 font-mono text-sm font-medium tabular-nums">
                       {bill.amount != null ? (
                         formatPHP(bill.amount)
                       ) : (
@@ -178,11 +178,11 @@ function PlaygroundBillListCard({
             <span className="flex items-center gap-1">
               <span
                 className={cn(
-                  "text-sm font-semibold tabular-nums",
+                  "font-mono text-sm font-semibold tabular-nums",
                   balance > 0
-                    ? "text-green-600 dark:text-green-400"
+                    ? "text-teal-700 dark:text-teal-300"
                     : balance < 0
-                      ? "text-red-600 dark:text-red-400"
+                      ? "text-rose-600 dark:text-rose-400"
                       : "",
                 )}
               >
@@ -199,13 +199,13 @@ function PlaygroundBillListCard({
             <div className="text-muted-foreground mt-2 space-y-1 border-t pt-2 text-xs">
               <div className="flex justify-between">
                 <span>Income</span>
-                <span className="tabular-nums">
+                <span className="font-mono tabular-nums">
                   {formatPHP(ingoing, "always")}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span>Bills</span>
-                <span className="tabular-nums">
+                <span className="font-mono tabular-nums">
                   {formatPHP(-outgoing, "always")}
                 </span>
               </div>

--- a/src/components/playgroundPage.tsx
+++ b/src/components/playgroundPage.tsx
@@ -35,15 +35,19 @@ function NoIncomeProfileState() {
   return (
     <div className="mx-auto max-w-5xl p-4 sm:p-6">
       <div className="flex flex-col items-center justify-center py-16">
-        <Receipt className="text-muted-foreground mb-4 size-12" />
-        <h2 className="text-2xl font-bold">Set Up Your Income First</h2>
-        <p className="text-muted-foreground mt-1 max-w-md text-center">
+        <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-4 flex size-12 items-center justify-center rounded-2xl">
+          <Receipt className="size-6" />
+        </span>
+        <h2 className="text-ledger-ink font-display text-2xl">
+          Set Up Your Income First
+        </h2>
+        <p className="text-ledger-muted mt-1 max-w-md text-center">
           To use the playground, you need to set up your income profile on the
           dashboard first.
         </p>
         <Link
           href="/dashboard"
-          className="text-primary mt-4 text-sm font-medium hover:underline"
+          className="text-ledger-accent-strong mt-4 text-sm font-medium hover:underline"
         >
           Go to Dashboard
         </Link>
@@ -54,7 +58,11 @@ function NoIncomeProfileState() {
 
 // Separated so incomeProfile can be passed as a concrete value,
 // avoiding the non-null assertion that would be needed if reading from context.
-function PlaygroundContent({ incomeProfile }: { incomeProfile: IncomeProfile }) {
+function PlaygroundContent({
+  incomeProfile,
+}: {
+  incomeProfile: IncomeProfile;
+}) {
   const { isInitialized } = usePlayground();
 
   if (!isInitialized) {

--- a/src/components/playgroundWorkspace.tsx
+++ b/src/components/playgroundWorkspace.tsx
@@ -83,7 +83,9 @@ export function PlaygroundWorkspace() {
       />
 
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">Bills by Pay Period</h2>
+        <h2 className="text-ledger-ink font-display text-xl">
+          Bills by Pay Period
+        </h2>
         <Button size="sm" onClick={() => setAddDialogOpen(true)}>
           Add Bill <CalendarPlus className="ml-1 size-4" />
         </Button>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,15 +1,15 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "~/lib/utils"
-import { Button } from "~/components/ui/button"
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
 
 function AlertDialog({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
@@ -17,7 +17,7 @@ function AlertDialogTrigger({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  )
+  );
 }
 
 function AlertDialogPortal({
@@ -25,7 +25,7 @@ function AlertDialogPortal({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  )
+  );
 }
 
 function AlertDialogOverlay({
@@ -37,11 +37,11 @@ function AlertDialogOverlay({
       data-slot="alert-dialog-overlay"
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogContent({
@@ -49,7 +49,7 @@ function AlertDialogContent({
   size = "default",
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
-  size?: "default" | "sm"
+  size?: "default" | "sm";
 }) {
   return (
     <AlertDialogPortal>
@@ -59,12 +59,12 @@ function AlertDialogContent({
         data-size={size}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
-          className
+          className,
         )}
         {...props}
       />
     </AlertDialogPortal>
-  )
+  );
 }
 
 function AlertDialogHeader({
@@ -76,11 +76,11 @@ function AlertDialogHeader({
       data-slot="alert-dialog-header"
       className={cn(
         "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogFooter({
@@ -92,11 +92,11 @@ function AlertDialogFooter({
       data-slot="alert-dialog-footer"
       className={cn(
         "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogTitle({
@@ -107,12 +107,12 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
-        className
+        "font-display text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogDescription({
@@ -125,7 +125,7 @@ function AlertDialogDescription({
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogMedia({
@@ -137,11 +137,11 @@ function AlertDialogMedia({
       data-slot="alert-dialog-media"
       className={cn(
         "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogAction({
@@ -159,7 +159,7 @@ function AlertDialogAction({
         {...props}
       />
     </Button>
-  )
+  );
 }
 
 function AlertDialogCancel({
@@ -177,7 +177,7 @@ function AlertDialogCancel({
         {...props}
       />
     </Button>
-  )
+  );
 }
 
 export {
@@ -193,4 +193,4 @@ export {
   AlertDialogPortal,
   AlertDialogTitle,
   AlertDialogTrigger,
-}
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,33 +1,33 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -39,11 +39,11 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -58,7 +58,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
+          className,
         )}
         {...props}
       >
@@ -69,7 +69,7 @@ function DialogContent({
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -79,7 +79,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -88,11 +88,11 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="dialog-footer"
       className={cn(
         "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogTitle({
@@ -102,10 +102,13 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn(
+        "font-display text-lg leading-none font-semibold",
+        className,
+      )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -118,7 +121,7 @@ function DialogDescription({
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -132,4 +135,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};


### PR DESCRIPTION
## Summary

**PR 3 of the UI consistency pass — the long tail.** Extends the emerald "quiet ledger" language to the remaining surfaces: forms, modals, `groupManager`, and the playground, so the whole app is cohesive with the landing (#25), shell/dashboard (#28), and bill list (#29).

### Changes
- **Modal titles → Fraunces at the primitive**: added `font-display` to `DialogTitle` and `AlertDialogTitle` in `ui/`. One change each, so *every* dialog/alert title app-wide (create/edit bill, group create + delete, edit income, delete confirms) is consistent from a single source — rather than touching 9+ call sites.
- **Page/section headings → Fraunces**: "Groups" (`groupManager`), "Setup Income Profile" (`createIncomeProfileForm`), "Create a new bill" (`createBillForm`), and the playground's "Bills by Pay Period" + "Set Up Your Income First" empty state.
- **Playground bill list harmonized with the dashboard** (`playgroundBillList`): amber/yellow → emerald accents (current-period ring/header/badge, due-today row), green/red → **teal/rose** balance (matching the app's money semantics), figures → Geist Mono.
- **Playground empty state**: emerald icon mark, Fraunces heading, emerald "Go to Dashboard" link.

### Test plan
- [x] `pnpm typecheck` — passes
- [x] `eslint` (8 files) — exit 0
- [x] `prettier --write` — formatted
- [x] Screenshot-verified: `/bills/create` ("Create a new bill" in Fraunces), `/groups` ("Groups" in Fraunces + emerald nav), and the **New group dialog title in Fraunces** — confirming the `DialogTitle` primitive change renders correctly across modals
- [ ] Populated `playgroundBillList` not screenshot-driven (same native `<input type="date">` automation blocker as #29); changes reuse `ledger-accent*` / `font-mono` / teal-rose utilities already verified in #25/#28/#29

### Notes
- Minor deferred detail: in-modal *amount* figures (billModal / playgroundBillModal bodies) still use `tabular-nums` sans rather than mono — a small follow-up if desired; their titles are now Fraunces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)