### PR TITLE
fix: bill-list eye toggle invisible on touch devices + mono modal amounts

### DIFF
--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -65,14 +65,16 @@ function BillRowItem({
       )}
       onClick={onClick}
     >
-      {/* Eye toggle — hidden until hover; always visible when excluded */}
+      {/* Eye toggle — always visible when excluded. Otherwise visible by
+          default (so it's reachable on touch), and only reveal-on-hover on
+          devices that actually support hover. */}
       <button
         type="button"
         className={cn(
           "shrink-0 transition-all",
           isExcluded
             ? "text-muted-foreground/60 opacity-100"
-            : "text-muted-foreground/60 hover:text-muted-foreground opacity-0 group-hover:opacity-100",
+            : "text-muted-foreground/60 hover:text-muted-foreground opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
         )}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/components/billViewMode.tsx
+++ b/src/components/billViewMode.tsx
@@ -70,7 +70,7 @@ export function BillViewMode({ bill, onEdit, onDelete }: BillViewModeProps) {
 
         <div>
           <label className="text-muted-foreground text-sm">Amount</label>
-          <p className="text-lg font-medium">
+          <p className="font-mono text-lg font-medium tabular-nums">
             {bill.amount != null ? (
               <>
                 ₱

--- a/src/components/playgroundBillModal.tsx
+++ b/src/components/playgroundBillModal.tsx
@@ -61,7 +61,7 @@ function PlaygroundBillViewMode({
 
         <div>
           <p className="text-muted-foreground text-sm">Amount</p>
-          <p className="text-lg font-medium">
+          <p className="font-mono text-lg font-medium tabular-nums">
             {bill.amount != null ? formatPHP(bill.amount) : "Not set"}
           </p>
         </div>
@@ -69,7 +69,9 @@ function PlaygroundBillViewMode({
         {bill.type === "single" ? (
           <div>
             <p className="text-muted-foreground text-sm">Due Date</p>
-            <p className="font-medium">{formatUtcDate(bill.date, "MMMM d, yyyy")}</p>
+            <p className="font-medium">
+              {formatUtcDate(bill.date, "MMMM d, yyyy")}
+            </p>
           </div>
         ) : (
           <div>
@@ -81,7 +83,8 @@ function PlaygroundBillViewMode({
             </p>
             {bill.recurrence.dtstart && (
               <p className="text-muted-foreground text-sm">
-                Starting {formatUtcDate(bill.recurrence.dtstart, "MMMM d, yyyy")}
+                Starting{" "}
+                {formatUtcDate(bill.recurrence.dtstart, "MMMM d, yyyy")}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary

Two small polish items:

### Fix: bill-list eye toggle was unreachable on mobile
The exclude/include **eye toggle** in the dashboard bill list (`billList.tsx`) was `opacity-0` until hover. On touch devices there is no hover, so the control was **invisible and unreachable** (reported from mobile).

The eye now shows **by default**, and reveal-on-hover is scoped to hover-capable devices via `[@media(hover:hover)]:`. Result: clean hover-reveal on desktop, always visible/tappable on touch. The excluded state was already always-visible and is unchanged.

Verified via computed style on a hover-capable browser: the element computes `opacity: 0` (so the media rule compiled and desktop behavior is preserved); on `hover: none` devices the media block doesn't match, so the base `opacity-100` applies and the eye is visible.

Also confirmed (grep) this was the **only** hover-only-visible control in the app — the playground list's eye was already always-visible.

### Tidy-up: mono in-modal amounts
The bill-detail amount (`billViewMode.tsx`, shown by `billModal`) and the playground bill-detail amount (`playgroundBillModal.tsx`) now render in **Geist Mono** (`font-mono tabular-nums`), matching the ledger figures used across the lists/cards. This closes the deferred item from #30.

### Test plan
- [x] `pnpm typecheck` — passes
- [x] `eslint` (3 files) — exit 0
- [x] `prettier --write` — formatted
- [x] Eye-toggle fix verified via computed-style check (opacity 0 on hover devices, falls back to visible on `hover: none`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)