### PR TITLE
feat: align remaining empty states + playground banner with the ledger

### DIFF
--- a/src/components/groupManager.tsx
+++ b/src/components/groupManager.tsx
@@ -18,7 +18,14 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { GripVertical, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  FolderTree,
+  GripVertical,
+  Loader2,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -304,8 +311,16 @@ export function GroupManager() {
             <Skeleton className="h-14 w-full" />
           </div>
         ) : orderedGroups.length === 0 ? (
-          <div className="rounded-lg border border-dashed py-12 text-center">
-            <p className="text-muted-foreground">No groups yet.</p>
+          <div className="border-ledger-line rounded-lg border border-dashed py-12 text-center">
+            <span className="bg-ledger-accent-soft text-ledger-accent-strong mx-auto mb-3 flex size-11 items-center justify-center rounded-2xl">
+              <FolderTree className="size-5" />
+            </span>
+            <h3 className="text-ledger-ink font-display text-lg">
+              No groups yet
+            </h3>
+            <p className="text-ledger-muted mt-1 text-sm">
+              Create a group to organize related bills together.
+            </p>
             <Button className="mt-4" onClick={() => setCreateOpen(true)}>
               <Plus className="mr-1 size-4" />
               Create your first group

--- a/src/components/playgroundBanner.tsx
+++ b/src/components/playgroundBanner.tsx
@@ -1,12 +1,12 @@
-import { AlertTriangle } from "lucide-react";
+import { Info } from "lucide-react";
 
 export function PlaygroundBanner() {
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
-      <AlertTriangle className="size-4 shrink-0" />
+    <div className="border-ledger-accent/20 bg-ledger-accent-soft/50 text-ledger-accent-strong flex items-center gap-2 rounded-lg border px-4 py-3">
+      <Info className="size-4 shrink-0" />
       <p className="text-sm">
-        <span className="font-medium">Playground Mode</span> — Changes are
-        temporary and won&apos;t be saved.
+        <span className="font-medium">Playground mode</span>
+        {" — changes are temporary and won't be saved."}
       </p>
     </div>
   );

--- a/src/components/playgroundWorkspace.tsx
+++ b/src/components/playgroundWorkspace.tsx
@@ -100,10 +100,12 @@ export function PlaygroundWorkspace() {
           removingBillIds={removingBillIds}
         />
       ) : (
-        <div className="flex flex-col items-center rounded-lg border border-dashed py-12">
-          <CalendarPlus className="text-muted-foreground mb-3 size-10" />
-          <h3 className="text-lg font-medium">No bills yet</h3>
-          <p className="text-muted-foreground mt-1 text-sm">
+        <div className="border-ledger-line flex flex-col items-center rounded-lg border border-dashed py-12">
+          <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-3 flex size-11 items-center justify-center rounded-2xl">
+            <CalendarPlus className="size-5" />
+          </span>
+          <h3 className="text-ledger-ink font-display text-lg">No bills yet</h3>
+          <p className="text-ledger-muted mt-1 text-sm">
             Add a hypothetical bill to see how it affects your budget.
           </p>
           <Button className="mt-4" onClick={() => setAddDialogOpen(true)}>


### PR DESCRIPTION
## Summary

Follow-on polish that closes the last gaps from the consistency audit — three surfaces that still used the old grayscale/amber styling now match the "quiet ledger" language.

### Changes
- **Groups empty state** (`groupManager.tsx`) — was a bare "No groups yet." line; now an **emerald FolderTree icon-mark + Fraunces heading + muted subtitle**, matching the dashboard/playground empty states.
- **Playground workspace empty state** (`playgroundWorkspace.tsx`) — its "No bills yet" used a plain muted icon; now the same **emerald CalendarPlus mark + Fraunces** treatment.
- **Playground banner** (`playgroundBanner.tsx`) — was the only remaining **amber** in the app. Since "changes won't be saved" is informational (not a warning), switched to an on-brand **emerald-soft info strip** with an `Info` icon. Also sentence-cased the copy and fixed the em-dash spacing ("Playground mode — changes…").

### Test plan
- [x] `pnpm typecheck` — passes
- [x] `eslint` (3 files) — exit 0
- [x] `prettier --write` — formatted
- [x] Screenshot-verified: `/groups` empty state, playground "Start Fresh" workspace (banner + empty state), and a zoom confirming the banner's em-dash spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)