### PR TITLE
feat: named recurrence cadences (fortnightly / quarterly / semi-annual / yearly)

### DIFF
--- a/src/components/billFormFields.tsx
+++ b/src/components/billFormFields.tsx
@@ -127,6 +127,11 @@ export function BillFormFields({
     setUseCustomFrequency(false);
     form.setValue("recurrence.type", preset.type);
     form.setValue("recurrence.interval", preset.interval);
+    // A named preset is a plain cadence, so drop any day-of-month pinning a
+    // legacy/imported bill carried. Otherwise the stale bymonthday makes
+    // presetFor return null (dropdown snaps back to "Custom") and persists an
+    // inconsistent recurrence that mis-fires through the bymonthday branch.
+    form.setValue("recurrence.bymonthday", undefined);
   };
 
   const handleInternalSubmit = (data: BillFormValues) => {

--- a/src/components/billFormFields.tsx
+++ b/src/components/billFormFields.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { useWatch, type UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import { api } from "~/trpc/react";
 import { colorForOrder } from "~/lib/group-colors";
+import { FREQUENCY_PRESETS, presetFor } from "~/lib/recurrence";
 import { DateInput } from "./dateInput";
 import {
   Form,
@@ -84,10 +86,48 @@ export function BillFormFields({
   });
   const groups = groupsData ?? [];
 
-  const [formType, formRecurrenceType] = useWatch({
-    name: ["type", "recurrence.type"],
+  const [
+    formType,
+    formRecurrenceType,
+    formRecurrenceInterval,
+    formRecurrenceBymonthday,
+  ] = useWatch({
+    name: [
+      "type",
+      "recurrence.type",
+      "recurrence.interval",
+      "recurrence.bymonthday",
+    ],
     control: form.control,
   });
+
+  // Legacy bills can carry an arbitrary interval (e.g. every 3 weeks) that maps
+  // to no named cadence; open those directly in the custom editor.
+  const [useCustomFrequency, setUseCustomFrequency] = useState(() => {
+    const recurrence = form.getValues("recurrence");
+    return recurrence ? presetFor(recurrence) === null : false;
+  });
+
+  const activePreset = presetFor({
+    type: formRecurrenceType ?? "monthly",
+    interval: formRecurrenceInterval ?? 1,
+    bymonthday: formRecurrenceBymonthday,
+  });
+  const frequencyValue = useCustomFrequency
+    ? "custom"
+    : (activePreset?.id ?? "custom");
+
+  const handleFrequencyChange = (value: string) => {
+    if (value === "custom") {
+      setUseCustomFrequency(true);
+      return;
+    }
+    const preset = FREQUENCY_PRESETS.find((p) => p.id === value);
+    if (!preset) return;
+    setUseCustomFrequency(false);
+    form.setValue("recurrence.type", preset.type);
+    form.setValue("recurrence.interval", preset.interval);
+  };
 
   const handleInternalSubmit = (data: BillFormValues) => {
     if (data.type === "recurring") {
@@ -177,9 +217,17 @@ export function BillFormFields({
 
         <Tabs
           value={formType}
-          onValueChange={(value) =>
-            form.setValue("type", value as BillFormValues["type"])
-          }
+          onValueChange={(value) => {
+            form.setValue("type", value as BillFormValues["type"]);
+            // Seed a default cadence the first time the repeating tab is opened
+            // so a preset is selected without the user touching the picker.
+            if (
+              value === "recurring" &&
+              form.getValues("recurrence.interval") == null
+            ) {
+              handleFrequencyChange("monthly");
+            }
+          }}
         >
           <TabsList className="w-full">
             <TabsTrigger value="single">Once</TabsTrigger>
@@ -201,55 +249,78 @@ export function BillFormFields({
             />
           </TabsContent>
           <TabsContent value="recurring" className="space-y-4">
-            <FormField
-              control={form.control}
-              name="recurrence.type"
-              defaultValue="monthly"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Every</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="weekly">Week</SelectItem>
-                      <SelectItem value="monthly">Month</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="recurrence.interval"
-              defaultValue={1}
-              rules={{ min: 1 }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    Repeats every {Number(field.value) || 1}{" "}
-                    {formRecurrenceType === "weekly"
-                      ? "week" + (Number(field.value) !== 1 ? "s" : "")
-                      : "month" + (Number(field.value) !== 1 ? "s" : "")}
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      placeholder="Interval"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className="space-y-2">
+              <Label>Frequency</Label>
+              <Select
+                value={frequencyValue}
+                onValueChange={handleFrequencyChange}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FREQUENCY_PRESETS.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="custom">Custom…</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {useCustomFrequency && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="recurrence.type"
+                  defaultValue="monthly"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Repeat unit</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="weekly">Week</SelectItem>
+                          <SelectItem value="monthly">Month</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="recurrence.interval"
+                  defaultValue={1}
+                  rules={{ min: 1 }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Repeats every {Number(field.value) || 1}{" "}
+                        {formRecurrenceType === "weekly"
+                          ? "week" + (Number(field.value) !== 1 ? "s" : "")
+                          : "month" + (Number(field.value) !== 1 ? "s" : "")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          placeholder="Interval"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
             <FormField
               control={form.control}
               name="recurrence.dtstart"

--- a/src/components/billFormFields.tsx
+++ b/src/components/billFormFields.tsx
@@ -109,8 +109,8 @@ export function BillFormFields({
   });
 
   const activePreset = presetFor({
-    type: formRecurrenceType ?? "monthly",
-    interval: formRecurrenceInterval ?? 1,
+    type: formRecurrenceType,
+    interval: formRecurrenceInterval,
     bymonthday: formRecurrenceBymonthday,
   });
   const frequencyValue = useCustomFrequency
@@ -268,7 +268,7 @@ export function BillFormFields({
                 </SelectContent>
               </Select>
             </div>
-            {useCustomFrequency && (
+            {frequencyValue === "custom" && (
               <>
                 <FormField
                   control={form.control}

--- a/src/components/billViewMode.tsx
+++ b/src/components/billViewMode.tsx
@@ -4,6 +4,7 @@ import { Calendar, Loader2, Repeat } from "lucide-react";
 import { toast } from "sonner";
 import { formatUtcDate } from "~/lib/date-utils";
 import { colorForOrder } from "~/lib/group-colors";
+import { formatRecurrence } from "~/lib/recurrence";
 import { api } from "~/trpc/react";
 import type { BillEvent } from "~/types";
 import { Badge } from "./ui/badge";
@@ -148,14 +149,7 @@ export function BillViewMode({ bill, onEdit, onDelete }: BillViewModeProps) {
                 Recurrence Pattern
               </label>
               <p className="font-medium">
-                Every {bill.recurrence.interval}{" "}
-                {bill.recurrence.type === "weekly"
-                  ? bill.recurrence.interval === 1
-                    ? "week"
-                    : "weeks"
-                  : bill.recurrence.interval === 1
-                    ? "month"
-                    : "months"}
+                {formatRecurrence(bill.recurrence)}
               </p>
             </div>
 

--- a/src/components/playgroundBillModal.tsx
+++ b/src/components/playgroundBillModal.tsx
@@ -5,6 +5,7 @@ import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { formatUtcDate } from "~/lib/date-utils";
+import { formatRecurrence } from "~/lib/recurrence";
 import type { PlaygroundBill, PlaygroundBillData } from "~/types";
 import {
   BillFormFields,
@@ -77,9 +78,7 @@ function PlaygroundBillViewMode({
           <div>
             <p className="text-muted-foreground text-sm">Schedule</p>
             <p className="font-medium">
-              Every {bill.recurrence.interval}{" "}
-              {bill.recurrence.type === "weekly" ? "week" : "month"}
-              {bill.recurrence.interval !== 1 ? "s" : ""}
+              {formatRecurrence(bill.recurrence)}
             </p>
             {bill.recurrence.dtstart && (
               <p className="text-muted-foreground text-sm">

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -43,11 +43,15 @@ interface RecurrenceLike {
 }
 
 /**
- * Returns the named preset a recurrence corresponds to, or null when it's a
- * custom cadence (an arbitrary interval, or one pinned to specific month-days)
- * that doesn't map to a named option.
+ * Returns the named preset a recurrence corresponds to, or null when it maps to
+ * no named option — an arbitrary interval, one pinned to specific month-days, or
+ * a recurrence whose type/interval isn't set yet (e.g. before a cadence is
+ * chosen).
  */
-export function presetFor(recurrence: RecurrenceLike): FrequencyPreset | null {
+export function presetFor(
+  recurrence: Partial<RecurrenceLike>,
+): FrequencyPreset | null {
+  if (recurrence.type == null || recurrence.interval == null) return null;
   if (recurrence.bymonthday && recurrence.bymonthday.length > 0) return null;
   return (
     FREQUENCY_PRESETS.find(

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,0 +1,69 @@
+// Named recurrence cadences (fortnightly, quarterly, …) are not distinct
+// storage types — they decompose onto the existing `{type, interval}` model the
+// scheduler already understands:
+//
+//   fortnightly  = weekly  × 2
+//   quarterly    = monthly × 3
+//   semi-annual  = monthly × 6
+//   yearly       = monthly × 12
+//
+// Keeping them as (base type, interval) pairs means the RRule mapping and the
+// short-month day-clamping in `bill-utils.ts` are reused verbatim — a yearly
+// bill dated Feb 29 clamps to Feb 28 for free because it flows through the same
+// monthly generator. This module is the single source of truth mapping those
+// pairs to/from the human-facing cadence names.
+
+export type RecurrenceBase = "weekly" | "monthly";
+
+export interface FrequencyPreset {
+  id: string;
+  label: string;
+  type: RecurrenceBase;
+  interval: number;
+}
+
+// Order here is the order shown in the picker. Each (type, interval) pair is
+// unique, so `presetFor` is an unambiguous reverse lookup.
+export const FREQUENCY_PRESETS: FrequencyPreset[] = [
+  { id: "weekly", label: "Weekly", type: "weekly", interval: 1 },
+  { id: "fortnightly", label: "Fortnightly", type: "weekly", interval: 2 },
+  { id: "monthly", label: "Monthly", type: "monthly", interval: 1 },
+  { id: "quarterly", label: "Quarterly", type: "monthly", interval: 3 },
+  { id: "semiannual", label: "Every 6 months", type: "monthly", interval: 6 },
+  { id: "yearly", label: "Yearly", type: "monthly", interval: 12 },
+];
+
+// The subset of a recurrence needed to name it. `bymonthday` matters because a
+// bill pinned to specific days-of-month is not a plain "monthly" cadence, so it
+// must not be labelled as a preset.
+interface RecurrenceLike {
+  type: RecurrenceBase;
+  interval: number;
+  bymonthday?: number[] | null;
+}
+
+/**
+ * Returns the named preset a recurrence corresponds to, or null when it's a
+ * custom cadence (an arbitrary interval, or one pinned to specific month-days)
+ * that doesn't map to a named option.
+ */
+export function presetFor(recurrence: RecurrenceLike): FrequencyPreset | null {
+  if (recurrence.bymonthday && recurrence.bymonthday.length > 0) return null;
+  return (
+    FREQUENCY_PRESETS.find(
+      (p) => p.type === recurrence.type && p.interval === recurrence.interval,
+    ) ?? null
+  );
+}
+
+/**
+ * Human-readable cadence: the preset name when one matches ("Quarterly"),
+ * otherwise a generic "Every N weeks/months" for custom intervals.
+ */
+export function formatRecurrence(recurrence: RecurrenceLike): string {
+  const preset = presetFor(recurrence);
+  if (preset) return preset.label;
+
+  const unit = recurrence.type === "weekly" ? "week" : "month";
+  return `Every ${recurrence.interval} ${unit}${recurrence.interval === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
Closes #36.

## What

Bills could previously recur only **weekly** or **monthly**. This adds **fortnightly, quarterly, semi-annual (every 6 months), and yearly** cadences through a single **Frequency** picker on the recurring-bill form.

## How — no schema or scheduler change

The four new cadences decompose cleanly onto the *existing* `{type, interval}` model the scheduler already understands:

| Cadence | Stored as |
|---|---|
| Fortnightly | `weekly` × 2 |
| Quarterly | `monthly` × 3 |
| Every 6 months | `monthly` × 6 |
| Yearly | `monthly` × 12 |

Because of this, **`RecurringBillSchema`, the `Recurrence` type, and `bill-utils` are untouched** — the RRule mapping and the short-month day-clamping already handle these intervals. In particular, a **Feb 29 yearly bill clamps to Feb 28** in non-leap years for free, because it flows through the same `monthlyOccurrencesInPeriod` generator (satisfying the issue's clamping acceptance criterion without new code).

> Note: the issue suggested updating the schema/type. It turned out the cleaner path needs neither — the interval field already expresses every target cadence. Flagging so it's a conscious call, not an oversight.

## Changes

- **`src/lib/recurrence.ts`** (new, pure, no imports): `FREQUENCY_PRESETS`, `presetFor()` (reverse lookup), and `formatRecurrence()` — the single source of truth mapping preset ↔ `{type, interval}` and rendering the human label. Shared by the picker and both bill views.
- **`billFormFields.tsx`**: the base-unit + interval controls become a **Frequency** dropdown. A **Custom…** option reveals the original controls, so the existing arbitrary-interval capability (e.g. "every 3 weeks") is preserved, and legacy bills with such intervals open straight into it.
- **`billViewMode.tsx` / `playgroundBillModal.tsx`**: cadence labels now go through `formatRecurrence` — "Every 2 weeks" reads "**Fortnightly**", "Every 1 month" reads "**Monthly**".

## Verification

- `pnpm typecheck` ✅ · `eslint` (changed files) ✅ · `pnpm build` ✅
- Driven live in the browser via the guest flow on `/bills/create`:
  - Repeating tab seeds **Monthly** by default
  - Dropdown lists all six presets + Custom
  - Selecting **Yearly** persists and displays; reverse-maps `monthly×12` → "Yearly"
  - **Custom…** reveals the manual controls with the prior interval (12) preserved
  - 0 console errors

## Notes for review

- ⚠️ The commit is **unsigned** — the 1Password SSH signing agent couldn't be unlocked during this autonomous run. `git commit --amend -S` to re-sign before merge if you want the verified badge.
- Open design question if you'd prefer to simplify: the **Custom…** escape hatch exists purely to avoid regressing arbitrary intervals. If you're happy to drop "every N weeks/months" entirely, the picker collapses to a plain 6-option dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
