### PR TITLE
feat: mark bill occurrences as paid (#34)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-mark-bill-occurrences-paid.md
+++ b/docs/superpowers/plans/2026-07-04-mark-bill-occurrences-paid.md
@@ -1,0 +1,585 @@
+# Mark Bill Occurrences as Paid — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user mark each occurrence of a bill paid/unpaid, so the dashboard's remaining balance reflects only what's still owed, persisted per occurrence.
+
+**Architecture:** Occurrences are generated client-side from recurrence rules, so paid-state is a sparse `payments` collection keyed by `(userId, billId, occurrenceDate)`, joined to generated occurrences in memory via a `Set` of composite keys. A row checkbox fires idempotent `markPaid`/`markUnpaid` tRPC mutations; a paid occurrence is treated exactly like an existing *excluded* row in every money sum.
+
+**Tech Stack:** Next.js 16 (App Router), tRPC 11 + SuperJSON, MongoDB native driver, TanStack React Query, Tailwind 4, lucide-react, sonner.
+
+**Design spec:** `docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md`
+
+## Global Constraints
+
+- **No test framework** (CLAUDE.md). Per-task verification = `pnpm typecheck` + `node_modules/.bin/eslint <changed files>` + (UI tasks) `SKIP_ENV_VALIDATION=1 pnpm build` + live-browser check.
+- **`next lint` / `pnpm lint` are broken under Next 16.** Lint changed files with `node_modules/.bin/eslint <path> …` directly; typecheck with `pnpm typecheck`.
+- **Commits are SSH-signed via the 1Password agent.** If a commit fails with `1Password: failed to fill whole buffer`, the agent is locked — commit with `--no-gpg-sign` and note it's unsigned.
+- **Every commit message ends with:** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+- **Date-only values are UTC-midnight instants** (see `src/lib/date-utils.ts`). The payment occurrence-key must stay in that frame.
+- **Path alias:** `~/` → `src/`.
+- **Branch:** `feat/mark-bill-occurrences-paid`. It already carries **uncommitted scaffolding** for Tasks 1–2 (the data model, `paymentRouter`, and `payment-utils.ts` join module). Those tasks finalize and commit that scaffolding.
+
+---
+
+### Task 1: Server foundation — `payments` collection, `paymentRouter`, `Payment` type
+
+**Files:**
+- Create: `src/server/api/routers/payment.ts` (already scaffolded on branch)
+- Modify: `src/server/api/root.ts` (already wired on branch)
+- Modify: `src/types/index.ts` (already added on branch)
+
+**Interfaces:**
+- Produces: tRPC `payment` router with `getAll(): Payment[]`, `markPaid({ billId: string, occurrenceDate: Date }): void`, `markUnpaid({ billId: string, occurrenceDate: Date }): void`.
+- Produces: `interface Payment { _id: string; userId: string; billId: string; occurrenceDate: Date; amountPaid?: number; paidAt: Date }` in `~/types`.
+
+- [ ] **Step 1: Apply the `deleteOne` → `deleteMany` fix in `markUnpaid`**
+
+In `src/server/api/routers/payment.ts`, the `markUnpaid` mutation must delete **all** matching rows (self-heals any duplicate created by a concurrent upsert race). Ensure the body reads:
+
+```ts
+markUnpaid: protectedProcedure
+  .input(z.object({ billId: z.string(), occurrenceDate: z.date() }))
+  .mutation(async ({ ctx, input }) => {
+    const billOid = await assertBillOwned(ctx, input.billId);
+
+    await ctx.db.collection<PaymentDoc>("payments").deleteMany({
+      userId: new ObjectId(ctx.session.user.id),
+      billId: billOid,
+      occurrenceDate: toOccurrenceKey(input.occurrenceDate),
+    });
+  }),
+```
+
+Confirm `src/server/api/root.ts` imports `paymentRouter` and registers it as `payment`, and `src/types/index.ts` exports the `Payment` interface above.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Lint the changed files**
+
+Run: `node_modules/.bin/eslint src/server/api/routers/payment.ts src/server/api/root.ts src/types/index.ts`
+Expected: no errors or warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/api/routers/payment.ts src/server/api/root.ts src/types/index.ts
+git commit -m "feat: add payments collection and paymentRouter (#34)
+
+New payment router with getAll/markPaid/markUnpaid over a sparse
+payments collection keyed by (userId, billId, occurrenceDate).
+markUnpaid uses deleteMany to self-heal any upsert-race duplicate.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Client join module — `payment-utils.ts`
+
+**Files:**
+- Create: `src/lib/payment-utils.ts` (already scaffolded on branch; `occurrenceKey` body is a stub that throws)
+
+**Interfaces:**
+- Consumes: `Payment` from `~/types`.
+- Produces:
+  - `occurrenceKey(billId: string, occurrenceDate: Date): string`
+  - `buildPaidLookup(payments: Payment[]): Set<string>`
+  - `isOccurrencePaid(paidKeys: Set<string>, billId: string, occurrenceDate: Date): boolean`
+
+- [ ] **Step 1: Implement `occurrenceKey`**
+
+Replace the stubbed body (the `throw`) in `src/lib/payment-utils.ts` with the timezone-stable encoding. `getTime()` is the UTC-based epoch, so the key matches whether it came from a generated occurrence or a stored payment:
+
+```ts
+export function occurrenceKey(billId: string, occurrenceDate: Date): string {
+  return `${billId}:${occurrenceDate.getTime()}`;
+}
+```
+
+Leave `buildPaidLookup` and `isOccurrencePaid` as scaffolded.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+Run: `node_modules/.bin/eslint src/lib/payment-utils.ts`
+Expected: no errors or warnings.
+
+> **Note:** No unit test — there is no test runner. `occurrenceKey`'s correctness (a paid marker lining up with its generated occurrence) is exercised end-to-end by the live check in Task 3 (mark paid → reload → still shows paid means the stored key matched the regenerated occurrence).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/payment-utils.ts
+git commit -m "feat: add occurrence/payment join helpers (#34)
+
+Timezone-stable (billId, occurrenceDate) key via getTime(), plus a
+Set-based paid lookup for joining generated occurrences to payments.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Bill-list UI — paid checkbox, styling, money math, mutations
+
+**Files:**
+- Modify: `src/app/_components/billList.tsx`
+
+**Interfaces:**
+- Consumes: `api.payment.getAll` / `markPaid` / `markUnpaid`; `buildPaidLookup`, `isOccurrencePaid`, `occurrenceKey` from `~/lib/payment-utils`.
+- Produces: no exported API change (`BillList` still takes no props).
+
+- [ ] **Step 1: Add imports**
+
+In `src/app/_components/billList.tsx`, extend the lucide import and add sonner + payment-utils:
+
+```tsx
+import { Circle, CircleCheckBig, EyeClosedIcon, EyeIcon, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import {
+  buildPaidLookup,
+  isOccurrencePaid,
+  occurrenceKey,
+} from "~/lib/payment-utils";
+```
+
+(Replace the existing `import { EyeClosedIcon, EyeIcon, Sparkles } from "lucide-react";` line.)
+
+- [ ] **Step 2: Extend `BillRowItem` with paid props and rendering**
+
+Replace the `BillRowItem` component with this version (adds the paid toggle button, dims the row when paid, strikes the amount; the existing eye/exclude toggle is unchanged):
+
+```tsx
+function BillRowItem({
+  bill,
+  payDate,
+  isExcluded,
+  isPaid,
+  isPaidPending,
+  onClick,
+  onToggleExclude,
+  onTogglePaid,
+}: {
+  bill: BillRow;
+  payDate: Date;
+  isExcluded: boolean;
+  isPaid: boolean;
+  isPaidPending: boolean;
+  onClick: () => void;
+  onToggleExclude: () => void;
+  onTogglePaid: () => void;
+}) {
+  const isDue = isSameDay(bill.date, payDate);
+
+  return (
+    <li
+      className={cn(
+        "group hover:bg-ledger-accent-soft/60 dark:hover:bg-ledger-accent/10 relative -mx-2 flex cursor-pointer items-center gap-3 rounded-xl px-2 py-2 transition-colors",
+        (isExcluded || isPaid) && "opacity-40",
+      )}
+      onClick={onClick}
+    >
+      {/* Paid toggle — persistent settled state. Always visible; disabled
+          while its mutation is in flight. */}
+      <button
+        type="button"
+        className={cn(
+          "shrink-0 transition-colors disabled:opacity-50",
+          isPaid
+            ? "text-ledger-accent-strong dark:text-ledger-accent"
+            : "text-muted-foreground/50 hover:text-muted-foreground",
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePaid();
+        }}
+        disabled={isPaidPending}
+        aria-label={isPaid ? "Mark unpaid" : "Mark paid"}
+        aria-pressed={isPaid}
+      >
+        {isPaid ? (
+          <CircleCheckBig className="size-4" />
+        ) : (
+          <Circle className="size-4" />
+        )}
+      </button>
+
+      {/* Eye toggle — transient exclude (planning). Always visible when
+          excluded. Otherwise visible by default (reachable on touch), and
+          reveal-on-hover only on devices that support hover. */}
+      <button
+        type="button"
+        className={cn(
+          "shrink-0 transition-all",
+          isExcluded
+            ? "text-muted-foreground/60 opacity-100"
+            : "text-muted-foreground/60 hover:text-muted-foreground opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleExclude();
+        }}
+        aria-label={isExcluded ? "Include bill" : "Exclude bill"}
+      >
+        {isExcluded ? (
+          <EyeClosedIcon className="size-3.5" />
+        ) : (
+          <EyeIcon className="size-3.5" />
+        )}
+      </button>
+
+      {/* Title + date */}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{bill.title}</div>
+        {!isExcluded && (
+          <div
+            className={cn(
+              "font-mono text-[11px] tabular-nums",
+              isDue
+                ? "text-ledger-accent-strong dark:text-ledger-accent"
+                : "text-muted-foreground",
+            )}
+          >
+            {isDue && (
+              <span className="bg-ledger-accent mr-1 inline-block size-2 rounded-full align-middle opacity-80" />
+            )}
+            {formatUtcDate(bill.date, "MMM d")}
+          </div>
+        )}
+      </div>
+
+      {/* Amount — struck through when paid */}
+      <span
+        className={cn(
+          "w-24 shrink-0 text-right font-mono text-sm font-semibold tracking-tight tabular-nums",
+          isPaid && "line-through",
+        )}
+      >
+        {!isExcluded ? (
+          bill.amount != null ? (
+            formatPHP(bill.amount)
+          ) : (
+            <span className="text-muted-foreground text-xs font-normal">—</span>
+          )
+        ) : null}
+      </span>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 3: Thread paid-state through `BillListCard`**
+
+`BillListCard` must (a) accept `paidKeys`, `pendingKeys`, and `onTogglePaid`; (b) exclude paid occurrences from `outgoing` and `subtotalFor`; (c) pass per-row paid state to `BillRowItem`. Update the signature and the two sums:
+
+Add to the destructured props and the prop type:
+
+```tsx
+function BillListCard({
+  bills,
+  groups,
+  payDate,
+  after,
+  isCurrent,
+  ingoing,
+  paidKeys,
+  pendingKeys,
+  onBillClick,
+  onTogglePaid,
+}: {
+  bills: BillRow[];
+  groups: Group[];
+  payDate: Date;
+  after: Date | null;
+  isCurrent: boolean;
+  ingoing: number;
+  paidKeys: Set<string>;
+  pendingKeys: Set<string>;
+  onBillClick: (billId: string) => void;
+  onTogglePaid: (bill: BillRow) => void;
+}) {
+```
+
+Replace the `outgoing` memo and `subtotalFor` so paid rows drop out (alongside excluded):
+
+```tsx
+  const outgoing = useMemo(
+    () =>
+      sumBy(
+        bills.filter(
+          (bill) =>
+            !excludedBills.includes(bill._id) &&
+            !isOccurrencePaid(paidKeys, bill._id, bill.date),
+        ),
+        (bill) => bill.amount ?? 0,
+      ),
+    [bills, excludedBills, paidKeys],
+  );
+```
+
+```tsx
+  const subtotalFor = (sectionBills: BillRow[]) =>
+    sumBy(
+      sectionBills.filter(
+        (b) =>
+          !excludedBills.includes(b._id) &&
+          !isOccurrencePaid(paidKeys, b._id, b.date),
+      ),
+      (b) => b.amount ?? 0,
+    );
+```
+
+Replace the `BillRowItem` render (inside `section.bills.map`) to pass paid state:
+
+```tsx
+                    {section.bills.map((bill) => {
+                      const key = occurrenceKey(bill._id, bill.date);
+                      return (
+                        <BillRowItem
+                          key={bill._id}
+                          bill={bill}
+                          payDate={payDate}
+                          isExcluded={excludedBills.includes(bill._id)}
+                          isPaid={paidKeys.has(key)}
+                          isPaidPending={pendingKeys.has(key)}
+                          onClick={() => onBillClick(bill._id)}
+                          onToggleExclude={() => toggleExclude(bill._id)}
+                          onTogglePaid={() => onTogglePaid(bill)}
+                        />
+                      );
+                    })}
+```
+
+- [ ] **Step 4: Wire the query, mutations, and pending-set in `BillList`**
+
+In the `BillList` component, add the payments query, paid lookup, per-occurrence pending set, and the toggle handler; pass them to each `BillListCard`. Add near the other queries:
+
+```tsx
+  const { data: payments } = api.payment.getAll.useQuery();
+  const utils = api.useUtils();
+  const markPaid = api.payment.markPaid.useMutation();
+  const markUnpaid = api.payment.markUnpaid.useMutation();
+  const [pendingKeys, setPendingKeys] = useState<Set<string>>(new Set());
+
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+
+  const handleTogglePaid = (bill: BillRow) => {
+    const key = occurrenceKey(bill._id, bill.date);
+    const currentlyPaid = paidKeys.has(key);
+    setPendingKeys((prev) => new Set(prev).add(key));
+    const mutation = currentlyPaid ? markUnpaid : markPaid;
+    mutation.mutate(
+      { billId: bill._id, occurrenceDate: bill.date },
+      {
+        onSuccess: () => utils.payment.getAll.invalidate(),
+        onError: (error) =>
+          toast.error(error.message || "Failed to update payment"),
+        onSettled: () =>
+          setPendingKeys((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          }),
+      },
+    );
+  };
+```
+
+Keep the existing `if (!incomeProfile || !bills || !groups) return null;` guard as-is (do **not** gate on `payments` — an unloaded payment set just means "nothing paid yet"). Then pass the new props in the `.map`:
+
+```tsx
+        {billsInPayPeriod.map(({ payDate, bills, after }, index) => (
+          <BillListCard
+            key={index}
+            payDate={payDate}
+            bills={bills}
+            groups={groups}
+            after={after}
+            isCurrent={index === 0}
+            ingoing={ingoing}
+            paidKeys={paidKeys}
+            pendingKeys={pendingKeys}
+            onBillClick={handleBillClick}
+            onTogglePaid={handleTogglePaid}
+          />
+        ))}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Lint**
+
+Run: `node_modules/.bin/eslint src/app/_components/billList.tsx`
+Expected: no errors or warnings.
+
+- [ ] **Step 7: Build**
+
+Run: `SKIP_ENV_VALIDATION=1 pnpm build`
+Expected: compiles successfully.
+
+- [ ] **Step 8: Live verification (per the `verify` skill)**
+
+Start the dev server (`pnpm dev --port 3001`; wait for `curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/` → `200`). In a fresh browser context: landing page → **Try as Guest** → set up an income profile → create a recurring monthly bill with an amount → open `/dashboard`.
+
+Verify:
+- Each occurrence row shows an empty circle; clicking it fills to a check, dims the row, strikes the amount, and the period card's balance rises by that amount ("going out" drops).
+- Reload the page → the occurrence is still shown paid (confirms the stored key matched the regenerated occurrence).
+- Click the check again → reverts to unpaid, balance drops back.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/app/_components/billList.tsx
+git commit -m "feat: mark occurrences paid from the bill list (#34)
+
+Row checkbox toggles markPaid/markUnpaid (disabled while pending);
+paid rows dim + strike and drop out of every period sum, exactly
+like an excluded row.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Summary cards — remaining balance and next-unpaid
+
+**Files:**
+- Modify: `src/components/financialSummaryCards.tsx`
+
+**Interfaces:**
+- Consumes: `api.payment.getAll`; `buildPaidLookup`, `isOccurrencePaid` from `~/lib/payment-utils`.
+
+- [ ] **Step 1: Add imports**
+
+In `src/components/financialSummaryCards.tsx`, add:
+
+```tsx
+import { api } from "~/trpc/react";
+import { buildPaidLookup, isOccurrencePaid } from "~/lib/payment-utils";
+```
+
+- [ ] **Step 2: Fetch payments and exclude paid from balance + next bill**
+
+Add the query and paid lookup at the top of the component body (above the existing `useMemo`), then filter `nextBill` and `totalBillAmount` to unpaid:
+
+```tsx
+  const { data: payments } = api.payment.getAll.useQuery();
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+
+  const { currentPeriodBills, nextBill } = useMemo(() => {
+    const payRule = createPayRule(incomeProfile);
+    const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
+    if (!currentPay) return { currentPeriodBills: [], nextBill: null };
+
+    const nextPayDate = payRule.after(currentPay);
+    if (!nextPayDate) return { currentPeriodBills: [], nextBill: null };
+
+    const periodBills = computeBillsInPeriod(bills, currentPay, nextPayDate);
+
+    const today = startOfDay(new Date());
+    const upcoming = periodBills.find(
+      (b) =>
+        utcDateOnlyToLocal(b.date) >= today &&
+        !isOccurrencePaid(paidKeys, b._id, b.date),
+    );
+
+    return { currentPeriodBills: periodBills, nextBill: upcoming ?? null };
+  }, [incomeProfile, bills, paidKeys]);
+
+  const income = incomeProfile.amount ?? 0;
+  const totalBillAmount = sumBy(
+    currentPeriodBills.filter((b) => !isOccurrencePaid(paidKeys, b._id, b.date)),
+    (b) => b.amount ?? 0,
+  );
+  const balance = income - totalBillAmount;
+```
+
+(The `useMemo` gains `paidKeys` in its dependency array; `totalBillAmount` now filters out paid occurrences. The "Total Bills" card still shows `bills.length` — unchanged.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Lint**
+
+Run: `node_modules/.bin/eslint src/components/financialSummaryCards.tsx`
+Expected: no errors or warnings.
+
+- [ ] **Step 5: Build**
+
+Run: `SKIP_ENV_VALIDATION=1 pnpm build`
+Expected: compiles successfully.
+
+- [ ] **Step 6: Live verification**
+
+With the dev server running and the guest session from Task 3: on `/dashboard`, note the **Balance** card and **Next Bill** card. Mark the nearest upcoming occurrence paid.
+
+Verify:
+- The **Balance** card's amount rises by the paid bill's amount (remaining excludes paid).
+- The **Next Bill** card advances to the next unpaid upcoming bill (or "None" if the current period is cleared — expected, period-scoped behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/financialSummaryCards.tsx
+git commit -m "feat: exclude paid occurrences from dashboard balance (#34)
+
+Summary balance now shows true remaining (unpaid only) and Next Bill
+skips already-paid occurrences.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full-branch verification and `/bills` route check
+
+**Files:**
+- Possibly modify: `src/app/bills/*` (only if it renders occurrences — see below)
+
+- [ ] **Step 1: Determine whether `/bills` renders occurrences**
+
+Run: `git grep -n "getPayPeriodsByCount\|computeBillsInPeriod\|BillRowItem\|<BillList" src/app/bills`
+Expected: identify whether the `/bills` route reuses `BillList` (inherits the checkbox for free) or renders a flat list of bill *definitions* (no dated occurrences → out of scope, no change). Record the finding.
+
+- [ ] **Step 2: Full typecheck + build**
+
+Run: `pnpm typecheck && SKIP_ENV_VALIDATION=1 pnpm build`
+Expected: both succeed.
+
+- [ ] **Step 3: End-to-end smoke (per `verify` skill)**
+
+With a fresh guest session: create both a **single** bill and a **recurring** bill → dashboard → mark an occurrence of each paid → reload → both persist as paid, balance reflects remaining → unmark one → reverts. Confirm no console errors beyond the known pre-existing noise (Better Auth "Base URL" warn, Radix "Missing Description for DialogContent").
+
+- [ ] **Step 4: (No commit unless Step 1 required a change.)** If `/bills` reused `BillList` and needed nothing, note it in the PR description. If it needed a change, implement it mirroring Task 3's row wiring, then typecheck + lint + build + commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Data model (`payments`, UTC-midnight key) → Task 1. ✓
+- `getAll` / `markPaid` / `markUnpaid`, ownership, idempotent upsert, `deleteMany` → Task 1. ✓
+- Join module (`occurrenceKey` timezone-stable, `buildPaidLookup`, `isOccurrencePaid`) → Task 2. ✓
+- Row checkbox, dim/strike, disable-while-pending, invalidate, toast → Task 3. ✓
+- Paid drops from subtotal/outgoing/balance like excluded (invariant preserved) → Task 3. ✓
+- Remaining balance + next-unpaid on summary cards → Task 4. ✓
+- Persistence across reload → verified in Tasks 3 & 5. ✓
+- Out of scope (overdue, amountPaid, history, playground) → not touched. ✓
+- `/bills` route confirmation → Task 5. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type consistency:** `occurrenceKey(billId, date)`, `buildPaidLookup(payments)`, `isOccurrencePaid(paidKeys, billId, date)`, `Payment`, and the `markPaid`/`markUnpaid` input shape `{ billId, occurrenceDate }` are used identically across Tasks 1–4. `onTogglePaid(bill)`, `paidKeys`, `pendingKeys` prop names match between `BillList` and `BillListCard`. ✓

--- a/docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md
+++ b/docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md
@@ -1,0 +1,175 @@
+# Design: Mark bill occurrences as paid — Issue #34
+
+- **Status:** Approved design (v1 scope)
+- **Date:** 2026-07-04
+- **Branch:** `feat/mark-bill-occurrences-paid`
+- **Issue:** #34 — *feat: mark bill occurrences as paid + payment history*
+
+## Problem
+
+There is no concept of a bill being **paid**. A `BillEvent` is purely a
+*schedule*; the dashboard sums every projected occurrence and assumes all of
+them are still owed. The moment a user pays anything mid-period, the "remaining"
+balance and per-period totals are wrong.
+
+## Scope
+
+**In (v1 — the core loop):**
+
+- Mark each **occurrence** paid / unpaid (a monthly bill has one occurrence per
+  month, each settled independently).
+- The dashboard's *remaining* balance (and per-period card balances) exclude
+  paid occurrences.
+- Paid state persists per occurrence across sessions and devices.
+
+**Out (deferred to follow-ups):**
+
+- Overdue state (unpaid + past-due styling).
+- `amountPaid` capture for variable bills.
+- A dedicated payment-history view.
+- The `/playground` — it is local-only guest state with no database, so payment
+  tracking does not apply there. Untouched.
+
+## Approach
+
+**Chosen: a separate `payments` collection, joined to occurrences on the
+client.**
+
+Occurrences are not stored — the dashboard generates them client-side from each
+bill's recurrence rule (`getPayPeriodsByCount` / `computeBillsInPeriod` inside
+`useMemo`). So paid-state cannot be a flag on an occurrence row; it is a sparse
+**side-set** keyed by `(billId, occurrenceDate)`, and the join happens in memory
+where the occurrences already exist.
+
+Alternatives rejected:
+
+- **Embed `paidOccurrences: Date[]` on the bill doc** — marking paid becomes a
+  read-modify-write on the shared bill document (lost-update risk on rapid
+  toggles), the array grows unbounded on long-lived recurring bills, and it does
+  not extend cleanly to `amountPaid` later.
+- **Move occurrence expansion to the server** — a large architectural inversion
+  of the current client-side generation, far beyond this feature's needs.
+
+## Data model
+
+New collection **`payments`**, one document per settled occurrence (sparse:
+absence of a document = unpaid):
+
+```
+{
+  _id:            ObjectId,
+  userId:         ObjectId,
+  billId:         ObjectId,
+  occurrenceDate: Date,   // UTC-midnight day-key, same frame as the scheduler
+  paidAt:         Date,   // when marked; server clock
+}
+```
+
+- Identity is the **`(userId, billId, occurrenceDate)`** triple.
+- `occurrenceDate` is normalized to UTC midnight on write
+  (`Date.UTC(y, m, d)`) so a stored marker lands in the exact frame that
+  `monthlyOccurrencesInPeriod` and RRule generate occurrences in
+  (see `src/lib/date-utils.ts`). This alignment is the feature's core
+  correctness condition.
+- No unique index in v1 — idempotency is handled at the query layer (below).
+  A unique compound index on the triple is noted as future hardening.
+
+## API — `paymentRouter`
+
+New router at `src/server/api/routers/payment.ts`, registered in
+`src/server/api/root.ts` as `payment`. Follows the existing `bill.ts` patterns
+(ObjectId handling, ownership check, serialize helper). All procedures are
+`protectedProcedure`.
+
+- **`getAll` (query)** → `Payment[]` for the current user, serialized (ObjectIds
+  → hex strings).
+- **`markPaid({ billId, occurrenceDate })` (mutation)** → verifies the bill
+  exists and is owned by the user, normalizes `occurrenceDate` to UTC midnight,
+  then an **idempotent upsert** on the identity triple, refreshing `paidAt`.
+  Marking the same occurrence twice yields one document.
+- **`markUnpaid({ billId, occurrenceDate })` (mutation)** → ownership check, then
+  **`deleteMany`** on the triple.
+
+Both mutations are commands (return nothing); reads go through `getAll`.
+
+**Why `deleteMany` (not `deleteOne`):** MongoDB upserts on a non-unique filter
+have a known concurrent-insert race — a fast double-click could create two
+documents for one occurrence. `deleteOne` would leave one behind and the user
+could not un-pay. `deleteMany` makes unmark self-healing; combined with
+disabling the checkbox while the mutation is in flight, duplicates are unlikely
+and harmless.
+
+## Client join — `src/lib/payment-utils.ts`
+
+Pure module. Owns the single encoding both sides agree on:
+
+- **`occurrenceKey(billId, date)`** → `` `${billId}:${date.getTime()}` ``.
+  `getTime()` is the UTC-based epoch, so the key is timezone-stable. Reading
+  local fields (`toDateString`, `getDate`) would shift the day across
+  timezones — the date-only-as-instant trap.
+- **`buildPaidLookup(payments)`** → `Set<string>` of those keys.
+- **`isOccurrencePaid(paidKeys, billId, date)`** → `paidKeys.has(...)`.
+
+## UI — dashboard bill list (`src/app/_components/billList.tsx`)
+
+- `BillList` fetches `api.payment.getAll.useQuery()`, builds `paidKeys` once with
+  `buildPaidLookup`, and threads it (plus an `onTogglePaid(billId, date)`
+  handler) down through `BillListCard` → `BillRowItem`.
+- **`BillRowItem`** gains a leading checkbox. Checked → row dimmed, amount
+  struck-through, ✓ shown. Toggling fires `payment.markPaid` / `markUnpaid`; the
+  checkbox is **disabled while the mutation is pending** and invalidates
+  `payment.getAll` on success — mirroring the existing `assignGroup` mutation
+  (disable-then-invalidate, `toast.error` on error). No optimistic-update
+  machinery in v1; the per-row disable does not block ticking other rows.
+- **Money math:** a paid occurrence is treated exactly like an existing
+  *excluded* row — it drops out of the section `subtotalFor`, the card's
+  `outgoing`, and therefore `balance`. This preserves the invariant that section
+  subtotals sum to the card's outgoing total. Paid visual state takes precedence
+  if a row is somehow both paid and excluded.
+
+## UI — summary cards (`src/components/financialSummaryCards.tsx`)
+
+Fetches `payment.getAll` (React Query dedupes the shared query — no extra
+network). `totalBillAmount` sums only **unpaid** current-period occurrences, so
+the **Balance** card shows true *remaining*. **Next Bill** skips paid
+occurrences (period-scoped as today; not widened to look into the next period).
+
+## Error handling
+
+- Mutations surface failures via `toast.error(...)` (matching `assignGroup`).
+- Ownership failures throw `TRPCError` `NOT_FOUND` (a payment can only attach to
+  a bill the requester owns).
+- Unmarking an already-unpaid occurrence and re-marking a paid one are both
+  no-op-safe (delete-many of zero rows; idempotent upsert).
+
+## Verification
+
+No test framework is configured; verify per the `verify` skill.
+
+1. `pnpm typecheck` + `eslint` clean; `SKIP_ENV_VALIDATION=1 pnpm build` succeeds.
+2. Live (guest session): create a recurring bill → dashboard → check an
+   occurrence paid → the row dims/strikes **and** that period's balance rises by
+   the bill's amount → reload → still paid → uncheck → reverts.
+3. Confirm whether the `/bills` route reuses `BillList` (gets the checkbox for
+   free) or renders a flat bill-definition list (no occurrences → no checkbox,
+   out of scope).
+
+## Follow-ups (not this PR)
+
+- Overdue state — pairs with #33 (reminders).
+- `amountPaid` for variable bills.
+- Payment-history view (the "+ payment history" in the issue title).
+- Unique compound index on `(userId, billId, occurrenceDate)`.
+
+## Files
+
+- `src/server/api/routers/payment.ts` — new.
+- `src/server/api/root.ts` — register `payment`.
+- `src/types/index.ts` — add `Payment`.
+- `src/lib/payment-utils.ts` — new (join helpers).
+- `src/app/_components/billList.tsx` — checkbox, paid styling, money math, mutations.
+- `src/components/financialSummaryCards.tsx` — unpaid balance, next-unpaid.
+
+The uncommitted scaffolding on the branch already covers the data model, API,
+and join module (with the `deleteOne` → `deleteMany` fix to apply); the bill-list
+and summary-card UI is the unwritten part.

--- a/docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md
+++ b/docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md
@@ -1,9 +1,26 @@
 # Design: Mark bill occurrences as paid — Issue #34
 
-- **Status:** Approved design (v1 scope)
+- **Status:** Approved design (v1 scope) — **revised after code review, see below**
 - **Date:** 2026-07-04
 - **Branch:** `feat/mark-bill-occurrences-paid`
 - **Issue:** #34 — *feat: mark bill occurrences as paid + payment history*
+
+> **Post-review revision (2026-07-04).** An xhigh code review found the original
+> "paid drops from *every* sum" money-math rule (below) to be incoherent: removing
+> paid bills from the period `outgoing` without also crediting income inflated the
+> balance and could flip "short" → "ahead". The coherent income-relative balance is
+> paid-invariant, so the implementation instead:
+> - keeps paid occurrences **in** the per-period card sums (`balance = income − all
+>   bills`, a stable projection); paid is shown there only as a struck-through row;
+> - renames the summary **"Balance"** card to **"Remaining"** = sum of *unpaid* bills
+>   (no income term), which shrinks toward ₱0 as bills are paid.
+>
+> The review also drove: cascade-deleting a bill's payments on `bill.delete`;
+> disabling the paid toggle through the refetch (stale-cache race); using the
+> per-occurrence key as the React list key; UTC-midnight-truncating the client
+> occurrence key; and dropping the unused `amountPaid` input. Deferred follow-ups:
+> unique index on the payments identity, bounding `payment.getAll` to the visible
+> window, and re-keying payments when a bill's schedule is edited.
 
 ## Problem
 

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -333,7 +333,7 @@ function BillListCard({
                       const key = occurrenceKey(bill._id, bill.date);
                       return (
                         <BillRowItem
-                          key={bill._id}
+                          key={key}
                           bill={bill}
                           payDate={payDate}
                           isExcluded={excludedBills.includes(bill._id)}
@@ -408,19 +408,26 @@ export function BillList() {
     const key = occurrenceKey(bill._id, bill.date);
     const currentlyPaid = paidKeys.has(key);
     setPendingKeys((prev) => new Set(prev).add(key));
+    const clearPending = () =>
+      setPendingKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     const mutation = currentlyPaid ? markUnpaid : markPaid;
     mutation.mutate(
       { billId: bill._id, occurrenceDate: bill.date },
       {
-        onSuccess: () => void utils.payment.getAll.invalidate(),
-        onError: (error) =>
-          toast.error(error.message || "Failed to update payment"),
-        onSettled: () =>
-          setPendingKeys((prev) => {
-            const next = new Set(prev);
-            next.delete(key);
-            return next;
-          }),
+        // Keep the row disabled until the refetch lands (invalidate resolves
+        // after it), not just the mutation response — otherwise paidKeys is
+        // still stale when the button re-enables and a fast re-click fires the
+        // same-direction mutation again.
+        onSuccess: () =>
+          void utils.payment.getAll.invalidate().finally(clearPending),
+        onError: (error) => {
+          toast.error(error.message || "Failed to update payment");
+          clearPending();
+        },
       },
     );
   };

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -2,11 +2,23 @@
 
 import { isSameDay, subDays } from "date-fns";
 import { sumBy } from "lodash";
-import { EyeClosedIcon, EyeIcon, Sparkles } from "lucide-react";
+import {
+  Circle,
+  CircleCheckBig,
+  EyeClosedIcon,
+  EyeIcon,
+  Sparkles,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { BillModal } from "~/components/billModal";
 import { getPayPeriodsByCount } from "~/lib/bill-utils";
 import { formatUtcDate } from "~/lib/date-utils";
+import {
+  buildPaidLookup,
+  isOccurrencePaid,
+  occurrenceKey,
+} from "~/lib/payment-utils";
 import { UNGROUPED_COLOR, colorForOrder } from "~/lib/group-colors";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
@@ -46,14 +58,20 @@ function BillRowItem({
   bill,
   payDate,
   isExcluded,
+  isPaid,
+  isPaidPending,
   onClick,
   onToggleExclude,
+  onTogglePaid,
 }: {
   bill: BillRow;
   payDate: Date;
   isExcluded: boolean;
+  isPaid: boolean;
+  isPaidPending: boolean;
   onClick: () => void;
   onToggleExclude: () => void;
+  onTogglePaid: () => void;
 }) {
   const isDue = isSameDay(bill.date, payDate);
 
@@ -61,10 +79,35 @@ function BillRowItem({
     <li
       className={cn(
         "group hover:bg-ledger-accent-soft/60 dark:hover:bg-ledger-accent/10 relative -mx-2 flex cursor-pointer items-center gap-3 rounded-xl px-2 py-2 transition-colors",
-        isExcluded && "opacity-40",
+        (isExcluded || isPaid) && "opacity-40",
       )}
       onClick={onClick}
     >
+      {/* Paid toggle — persistent settled state. Always visible; disabled
+          while its mutation is in flight. */}
+      <button
+        type="button"
+        className={cn(
+          "shrink-0 transition-colors disabled:opacity-50",
+          isPaid
+            ? "text-ledger-accent-strong dark:text-ledger-accent"
+            : "text-muted-foreground/50 hover:text-muted-foreground",
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePaid();
+        }}
+        disabled={isPaidPending}
+        aria-label={isPaid ? "Mark unpaid" : "Mark paid"}
+        aria-pressed={isPaid}
+      >
+        {isPaid ? (
+          <CircleCheckBig className="size-4" />
+        ) : (
+          <Circle className="size-4" />
+        )}
+      </button>
+
       {/* Eye toggle — always visible when excluded. Otherwise visible by
           default (so it's reachable on touch), and only reveal-on-hover on
           devices that actually support hover. */}
@@ -109,8 +152,13 @@ function BillRowItem({
         )}
       </div>
 
-      {/* Amount — fixed-width right-aligned column */}
-      <span className="w-24 shrink-0 text-right font-mono text-sm font-semibold tracking-tight tabular-nums">
+      {/* Amount — fixed-width right-aligned column; struck through when paid */}
+      <span
+        className={cn(
+          "w-24 shrink-0 text-right font-mono text-sm font-semibold tracking-tight tabular-nums",
+          isPaid && "line-through",
+        )}
+      >
         {!isExcluded ? (
           bill.amount != null ? (
             formatPHP(bill.amount)
@@ -130,7 +178,10 @@ function BillListCard({
   after,
   isCurrent,
   ingoing,
+  paidKeys,
+  pendingKeys,
   onBillClick,
+  onTogglePaid,
 }: {
   bills: BillRow[];
   groups: Group[];
@@ -138,7 +189,10 @@ function BillListCard({
   after: Date | null;
   isCurrent: boolean;
   ingoing: number;
+  paidKeys: Set<string>;
+  pendingKeys: Set<string>;
   onBillClick: (billId: string) => void;
+  onTogglePaid: (bill: BillRow) => void;
 }) {
   const [excludedBills, setExcludedBills] = useState<string[]>([]);
 
@@ -147,10 +201,14 @@ function BillListCard({
   const outgoing = useMemo(
     () =>
       sumBy(
-        bills.filter((bill) => !excludedBills.includes(bill._id)),
+        bills.filter(
+          (bill) =>
+            !excludedBills.includes(bill._id) &&
+            !isOccurrencePaid(paidKeys, bill._id, bill.date),
+        ),
         (bill) => bill.amount ?? 0,
       ),
-    [bills, excludedBills],
+    [bills, excludedBills, paidKeys],
   );
 
   const balance = ingoing - outgoing;
@@ -165,7 +223,11 @@ function BillListCard({
 
   const subtotalFor = (sectionBills: BillRow[]) =>
     sumBy(
-      sectionBills.filter((b) => !excludedBills.includes(b._id)),
+      sectionBills.filter(
+        (b) =>
+          !excludedBills.includes(b._id) &&
+          !isOccurrencePaid(paidKeys, b._id, b.date),
+      ),
       (b) => b.amount ?? 0,
     );
 
@@ -267,16 +329,22 @@ function BillListCard({
 
                   {/* Bill rows */}
                   <ul>
-                    {section.bills.map((bill) => (
-                      <BillRowItem
-                        key={bill._id}
-                        bill={bill}
-                        payDate={payDate}
-                        isExcluded={excludedBills.includes(bill._id)}
-                        onClick={() => onBillClick(bill._id)}
-                        onToggleExclude={() => toggleExclude(bill._id)}
-                      />
-                    ))}
+                    {section.bills.map((bill) => {
+                      const key = occurrenceKey(bill._id, bill.date);
+                      return (
+                        <BillRowItem
+                          key={bill._id}
+                          bill={bill}
+                          payDate={payDate}
+                          isExcluded={excludedBills.includes(bill._id)}
+                          isPaid={paidKeys.has(key)}
+                          isPaidPending={pendingKeys.has(key)}
+                          onClick={() => onBillClick(bill._id)}
+                          onToggleExclude={() => toggleExclude(bill._id)}
+                          onTogglePaid={() => onTogglePaid(bill)}
+                        />
+                      );
+                    })}
                   </ul>
                 </div>
               );
@@ -295,10 +363,17 @@ export function BillList() {
   const { data: bills } = api.bill.getAll.useQuery();
   const { data: incomeProfile } = api.income.getIncomeProfile.useQuery();
   const { data: groups } = api.group.getAll.useQuery();
+  const { data: payments } = api.payment.getAll.useQuery();
+  const utils = api.useUtils();
+  const markPaid = api.payment.markPaid.useMutation();
+  const markUnpaid = api.payment.markUnpaid.useMutation();
+  const [pendingKeys, setPendingKeys] = useState<Set<string>>(new Set());
   const [selectedBillId, setSelectedBillId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [visibleCount, setVisibleCount] = useState(PERIODS_INITIAL);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
 
   const billsInPayPeriod = useMemo(() => {
     if (!bills || !incomeProfile) return [];
@@ -329,6 +404,27 @@ export function BillList() {
     setModalOpen(true);
   };
 
+  const handleTogglePaid = (bill: BillRow) => {
+    const key = occurrenceKey(bill._id, bill.date);
+    const currentlyPaid = paidKeys.has(key);
+    setPendingKeys((prev) => new Set(prev).add(key));
+    const mutation = currentlyPaid ? markUnpaid : markPaid;
+    mutation.mutate(
+      { billId: bill._id, occurrenceDate: bill.date },
+      {
+        onSuccess: () => void utils.payment.getAll.invalidate(),
+        onError: (error) =>
+          toast.error(error.message || "Failed to update payment"),
+        onSettled: () =>
+          setPendingKeys((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          }),
+      },
+    );
+  };
+
   return (
     <>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -341,7 +437,10 @@ export function BillList() {
             after={after}
             isCurrent={index === 0}
             ingoing={ingoing}
+            paidKeys={paidKeys}
+            pendingKeys={pendingKeys}
             onBillClick={handleBillClick}
+            onTogglePaid={handleTogglePaid}
           />
         ))}
       </div>

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -14,11 +14,7 @@ import { toast } from "sonner";
 import { BillModal } from "~/components/billModal";
 import { getPayPeriodsByCount } from "~/lib/bill-utils";
 import { formatUtcDate } from "~/lib/date-utils";
-import {
-  buildPaidLookup,
-  isOccurrencePaid,
-  occurrenceKey,
-} from "~/lib/payment-utils";
+import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
 import { UNGROUPED_COLOR, colorForOrder } from "~/lib/group-colors";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
@@ -198,17 +194,16 @@ function BillListCard({
 
   const sections = useMemo(() => buildSections(bills, groups), [bills, groups]);
 
+  // Paid occurrences stay in the period sums — the card balance is a stable
+  // income−all-bills projection, not "cash left". Paid is shown as a struck row;
+  // "remaining to pay" lives in the summary cards instead.
   const outgoing = useMemo(
     () =>
       sumBy(
-        bills.filter(
-          (bill) =>
-            !excludedBills.includes(bill._id) &&
-            !isOccurrencePaid(paidKeys, bill._id, bill.date),
-        ),
+        bills.filter((bill) => !excludedBills.includes(bill._id)),
         (bill) => bill.amount ?? 0,
       ),
-    [bills, excludedBills, paidKeys],
+    [bills, excludedBills],
   );
 
   const balance = ingoing - outgoing;
@@ -223,11 +218,7 @@ function BillListCard({
 
   const subtotalFor = (sectionBills: BillRow[]) =>
     sumBy(
-      sectionBills.filter(
-        (b) =>
-          !excludedBills.includes(b._id) &&
-          !isOccurrencePaid(paidKeys, b._id, b.date),
-      ),
+      sectionBills.filter((b) => !excludedBills.includes(b._id)),
       (b) => b.amount ?? 0,
     );
 

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -29,12 +29,11 @@ function formatPHP(value: number) {
   });
 }
 
-// Color the balance by sign so it agrees with the bill list's money semantics:
-// teal reads as "ahead", rose as "short".
-function balanceToneClass(balance: number) {
-  if (balance > 0) return "text-teal-700 dark:text-teal-300";
-  if (balance < 0) return "text-rose-600 dark:text-rose-400";
-  return "text-ledger-ink";
+// Fully paid reads as "all clear" (teal); anything still owed stays neutral ink.
+function remainingToneClass(remaining: number) {
+  return remaining === 0
+    ? "text-teal-700 dark:text-teal-300"
+    : "text-ledger-ink";
 }
 
 type SummaryCard = {
@@ -80,12 +79,13 @@ export function FinancialSummaryCards({
   }, [incomeProfile, bills, paidKeys]);
 
   const income = incomeProfile.amount ?? 0;
-  // Remaining balance reflects only what's still owed — paid occurrences drop out.
-  const totalBillAmount = sumBy(
+  // What's still owed this period — paid occurrences drop out. This is a plain
+  // remaining-to-pay total (no income term), so it stays coherent and shrinks
+  // toward ₱0 as bills are marked paid, whatever the income is.
+  const remaining = sumBy(
     currentPeriodBills.filter((b) => !isOccurrencePaid(paidKeys, b._id, b.date)),
     (b) => b.amount ?? 0,
   );
-  const balance = income - totalBillAmount;
 
   const cards: SummaryCard[] = [
     {
@@ -104,11 +104,11 @@ export function FinancialSummaryCards({
     },
     {
       icon: PiggyBank,
-      label: "Balance",
-      value: formatPHP(balance),
-      subtitle: "This period",
+      label: "Remaining",
+      value: formatPHP(remaining),
+      subtitle: "Left to pay this period",
       mono: true,
-      valueClassName: balanceToneClass(balance),
+      valueClassName: remainingToneClass(remaining),
     },
     {
       icon: CalendarClock,

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -55,19 +55,26 @@ export function FinancialSummaryCards({
   const { data: payments } = api.payment.getAll.useQuery();
   const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
 
-  const { currentPeriodBills, nextBill } = useMemo(() => {
+  const { remaining, nextBill } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
     const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
-    if (!currentPay) return { currentPeriodBills: [], nextBill: null };
+    if (!currentPay) return { remaining: 0, nextBill: null };
 
     const nextPayDate = payRule.after(currentPay);
-    if (!nextPayDate) return { currentPeriodBills: [], nextBill: null };
+    if (!nextPayDate) return { remaining: 0, nextBill: null };
 
     const periodBills = computeBillsInPeriod(bills, currentPay, nextPayDate);
 
-    // Find the nearest upcoming *unpaid* bill (today or future). Compare on day
-    // granularity: bill dates are at midnight, so `b.date >= new Date()` would
-    // drop a bill due today once the wall clock passes midnight.
+    // What's still owed this period — paid occurrences contribute 0. A plain
+    // remaining-to-pay total (no income term), so it stays coherent and shrinks
+    // toward ₱0 as bills are marked paid, whatever the income is.
+    const remaining = sumBy(periodBills, (b) =>
+      isOccurrencePaid(paidKeys, b._id, b.date) ? 0 : (b.amount ?? 0),
+    );
+
+    // Nearest upcoming *unpaid* bill (today or future). Day-granularity compare:
+    // bill dates are at midnight, so `b.date >= new Date()` would drop a bill due
+    // today once the wall clock passes midnight.
     const today = startOfDay(new Date());
     const upcoming = periodBills.find(
       (b) =>
@@ -75,17 +82,10 @@ export function FinancialSummaryCards({
         !isOccurrencePaid(paidKeys, b._id, b.date),
     );
 
-    return { currentPeriodBills: periodBills, nextBill: upcoming ?? null };
+    return { remaining, nextBill: upcoming ?? null };
   }, [incomeProfile, bills, paidKeys]);
 
   const income = incomeProfile.amount ?? 0;
-  // What's still owed this period — paid occurrences drop out. This is a plain
-  // remaining-to-pay total (no income term), so it stays coherent and shrinks
-  // toward ₱0 as bills are marked paid, whatever the income is.
-  const remaining = sumBy(
-    currentPeriodBills.filter((b) => !isOccurrencePaid(paidKeys, b._id, b.date)),
-    (b) => b.amount ?? 0,
-  );
 
   const cards: SummaryCard[] = [
     {

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -18,6 +18,8 @@ import {
   localDateToUtcDateOnly,
   utcDateOnlyToLocal,
 } from "~/lib/date-utils";
+import { buildPaidLookup, isOccurrencePaid } from "~/lib/payment-utils";
+import { api } from "~/trpc/react";
 import type { BillEvent, IncomeProfile } from "~/types";
 
 function formatPHP(value: number) {
@@ -51,6 +53,9 @@ export function FinancialSummaryCards({
   incomeProfile: IncomeProfile;
   bills: BillEvent[];
 }) {
+  const { data: payments } = api.payment.getAll.useQuery();
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+
   const { currentPeriodBills, nextBill } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
     const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
@@ -61,19 +66,25 @@ export function FinancialSummaryCards({
 
     const periodBills = computeBillsInPeriod(bills, currentPay, nextPayDate);
 
-    // Find the nearest upcoming bill (today or future). Compare on day
+    // Find the nearest upcoming *unpaid* bill (today or future). Compare on day
     // granularity: bill dates are at midnight, so `b.date >= new Date()` would
     // drop a bill due today once the wall clock passes midnight.
     const today = startOfDay(new Date());
     const upcoming = periodBills.find(
-      (b) => utcDateOnlyToLocal(b.date) >= today,
+      (b) =>
+        utcDateOnlyToLocal(b.date) >= today &&
+        !isOccurrencePaid(paidKeys, b._id, b.date),
     );
 
     return { currentPeriodBills: periodBills, nextBill: upcoming ?? null };
-  }, [incomeProfile, bills]);
+  }, [incomeProfile, bills, paidKeys]);
 
   const income = incomeProfile.amount ?? 0;
-  const totalBillAmount = sumBy(currentPeriodBills, (b) => b.amount ?? 0);
+  // Remaining balance reflects only what's still owed — paid occurrences drop out.
+  const totalBillAmount = sumBy(
+    currentPeriodBills.filter((b) => !isOccurrencePaid(paidKeys, b._id, b.date)),
+    (b) => b.amount ?? 0,
+  );
   const balance = income - totalBillAmount;
 
   const cards: SummaryCard[] = [

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -37,6 +37,20 @@ export function utcDateOnlyToLocal(utc: Date): Date {
   return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate());
 }
 
+/**
+ * Floor a `Date` to UTC midnight of its own UTC calendar day. Unlike
+ * `localDateToUtcDateOnly` (which reads local fields) this keeps the UTC day, and
+ * unlike `roundToUtcDateOnly` it floors rather than rounds. It's the canonical
+ * key for occurrences in the UTC-naive frame: the client occurrence key and the
+ * server-stored payment date both pass through it, so their days stay
+ * byte-identical for the in-memory paid-state join.
+ */
+export function truncateToUtcDateOnly(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
 /** Format a canonical (UTC-midnight) value by its calendar day, timezone-stably. */
 export function formatUtcDate(date: Date, formatStr: string): string {
   return format(utcDateOnlyToLocal(date), formatStr);

--- a/src/lib/payment-utils.ts
+++ b/src/lib/payment-utils.ts
@@ -1,3 +1,4 @@
+import { truncateToUtcDateOnly } from "~/lib/date-utils";
 import type { Payment } from "~/types";
 
 // Occurrences are generated client-side from recurrence rules, and paid-state
@@ -10,21 +11,14 @@ import type { Payment } from "~/types";
 /**
  * Stable composite key identifying one occurrence of a bill.
  *
- * The date is truncated to its UTC-midnight epoch — matching the server's
- * `toOccurrenceKey` (payment.ts) — so the read-side key lines up with the stored
- * payment even if a bill's date ever carries a sub-day time component. Keying off
- * UTC fields keeps it timezone-stable (reading local fields would shift the day
- * for users east/west of UTC — the date-only-as-instant trap; see date-utils.ts).
- * The `:` separator can't appear in a hex ObjectId string, so bill and day never
- * collide.
+ * The date is floored to its UTC-midnight day via the shared
+ * `truncateToUtcDateOnly` — the same helper the server applies before storing a
+ * payment — so the read-side key lines up with the stored day even if a bill's
+ * date ever carries a sub-day time component. The `:` separator can't appear in a
+ * hex ObjectId string, so bill and day never collide.
  */
 export function occurrenceKey(billId: string, occurrenceDate: Date): string {
-  const utcMidnight = Date.UTC(
-    occurrenceDate.getUTCFullYear(),
-    occurrenceDate.getUTCMonth(),
-    occurrenceDate.getUTCDate(),
-  );
-  return `${billId}:${utcMidnight}`;
+  return `${billId}:${truncateToUtcDateOnly(occurrenceDate).getTime()}`;
 }
 
 /** Build the O(1) lookup of paid occurrences from the user's payment set. */

--- a/src/lib/payment-utils.ts
+++ b/src/lib/payment-utils.ts
@@ -1,0 +1,38 @@
+import type { Payment } from "~/types";
+
+// Occurrences are generated client-side from recurrence rules, and paid-state
+// lives in a separate sparse `payments` set. To render each occurrence's paid
+// status we join the two in memory: encode every occurrence as a stable string
+// key, drop the paid ones into a Set, then test each generated occurrence
+// against it. This module owns that key so the write side (a payment row) and
+// the read side (a generated occurrence) agree on exactly one encoding.
+
+/**
+ * Stable composite key identifying one occurrence of a bill.
+ *
+ * `getTime()` is the UTC-based epoch, so a generated occurrence and a stored
+ * payment for the same calendar day produce the identical key in every
+ * timezone. Reading local fields (`toDateString`/`getDate`) would shift the day
+ * for users east/west of UTC — the date-only-as-instant trap (see
+ * date-utils.ts). The `:` separator can't appear in a hex ObjectId string, so
+ * bill and day never collide.
+ */
+export function occurrenceKey(billId: string, occurrenceDate: Date): string {
+  return `${billId}:${occurrenceDate.getTime()}`;
+}
+
+/** Build the O(1) lookup of paid occurrences from the user's payment set. */
+export function buildPaidLookup(payments: Payment[]): Set<string> {
+  return new Set(
+    payments.map((p) => occurrenceKey(p.billId, p.occurrenceDate)),
+  );
+}
+
+/** True when the given occurrence has a payment recorded against it. */
+export function isOccurrencePaid(
+  paidKeys: Set<string>,
+  billId: string,
+  occurrenceDate: Date,
+): boolean {
+  return paidKeys.has(occurrenceKey(billId, occurrenceDate));
+}

--- a/src/lib/payment-utils.ts
+++ b/src/lib/payment-utils.ts
@@ -10,15 +10,21 @@ import type { Payment } from "~/types";
 /**
  * Stable composite key identifying one occurrence of a bill.
  *
- * `getTime()` is the UTC-based epoch, so a generated occurrence and a stored
- * payment for the same calendar day produce the identical key in every
- * timezone. Reading local fields (`toDateString`/`getDate`) would shift the day
- * for users east/west of UTC — the date-only-as-instant trap (see
- * date-utils.ts). The `:` separator can't appear in a hex ObjectId string, so
- * bill and day never collide.
+ * The date is truncated to its UTC-midnight epoch — matching the server's
+ * `toOccurrenceKey` (payment.ts) — so the read-side key lines up with the stored
+ * payment even if a bill's date ever carries a sub-day time component. Keying off
+ * UTC fields keeps it timezone-stable (reading local fields would shift the day
+ * for users east/west of UTC — the date-only-as-instant trap; see date-utils.ts).
+ * The `:` separator can't appear in a hex ObjectId string, so bill and day never
+ * collide.
  */
 export function occurrenceKey(billId: string, occurrenceDate: Date): string {
-  return `${billId}:${occurrenceDate.getTime()}`;
+  const utcMidnight = Date.UTC(
+    occurrenceDate.getUTCFullYear(),
+    occurrenceDate.getUTCMonth(),
+    occurrenceDate.getUTCDate(),
+  );
+  return `${billId}:${utcMidnight}`;
 }
 
 /** Build the O(1) lookup of paid occurrences from the user's payment set. */

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { billRouter } from "~/server/api/routers/bill";
 import { groupRouter } from "~/server/api/routers/group";
+import { paymentRouter } from "~/server/api/routers/payment";
 import { postRouter } from "~/server/api/routers/post";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { incomeRouter } from "./routers/income";
@@ -14,6 +15,7 @@ export const appRouter = createTRPCRouter({
   bill: billRouter,
   group: groupRouter,
   income: incomeRouter,
+  payment: paymentRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -128,14 +128,21 @@ export const billRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
       }
 
-      const result = await ctx.db.collection("bills").deleteOne({
-        _id: new ObjectId(input.id),
-        userId: new ObjectId(ctx.session.user.id),
-      });
+      const billOid = new ObjectId(input.id);
+      const userOid = new ObjectId(ctx.session.user.id);
+      const result = await ctx.db
+        .collection("bills")
+        .deleteOne({ _id: billOid, userId: userOid });
 
       if (result.deletedCount === 0) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
       }
+
+      // Cascade: drop any paid-occurrence markers for this bill so they don't
+      // orphan in the payments collection.
+      await ctx.db
+        .collection("payments")
+        .deleteMany({ userId: userOid, billId: billOid });
     }),
   create: protectedProcedure
     .input(InputBillSchema)

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -13,7 +13,6 @@ type PaymentDoc = {
   userId: ObjectId;
   billId: ObjectId;
   occurrenceDate: Date;
-  amountPaid?: number;
   paidAt: Date;
 };
 
@@ -70,29 +69,22 @@ export const paymentRouter = createTRPCRouter({
     return payments.map(serializePayment);
   }),
   markPaid: protectedProcedure
-    .input(
-      z.object({
-        billId: z.string(),
-        occurrenceDate: z.date(),
-        amountPaid: z.number().min(0).optional(),
-      }),
-    )
+    .input(z.object({ billId: z.string(), occurrenceDate: z.date() }))
     .mutation(async ({ ctx, input }) => {
       const billOid = await assertBillOwned(ctx, input.billId);
       const occurrenceDate = toOccurrenceKey(input.occurrenceDate);
 
-      // Upsert on the (userId, billId, occurrenceDate) identity so marking the
-      // same occurrence paid twice refreshes paidAt instead of duplicating.
-      const set: Record<string, unknown> = { paidAt: new Date() };
-      if (input.amountPaid != null) set.amountPaid = input.amountPaid;
-
+      // Upsert on the (userId, billId, occurrenceDate) identity so re-marking the
+      // same occurrence refreshes paidAt rather than adding a row. Without a
+      // unique index, truly concurrent upserts can still race to insert
+      // duplicates — deferred; markUnpaid's deleteMany clears any that appear.
       await ctx.db.collection<WithoutId<PaymentDoc>>("payments").updateOne(
         {
           userId: new ObjectId(ctx.session.user.id),
           billId: billOid,
           occurrenceDate,
         },
-        { $set: set },
+        { $set: { paidAt: new Date() } },
         { upsert: true },
       );
     }),

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { ObjectId, type Db, type WithoutId } from "mongodb";
 import { z } from "zod";
+import { truncateToUtcDateOnly } from "~/lib/date-utils";
 import type { Payment as SerializedPayment } from "~/types";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
@@ -25,22 +26,13 @@ function serializePayment(payment: PaymentDoc): SerializedPayment {
   };
 }
 
-// Truncate an occurrence instant to UTC midnight of its calendar day, so the
-// stored key sits in the same UTC-naive frame the scheduler generates
-// occurrences in (see date-utils.ts). Without this a paid marker could miss its
-// occurrence by a sub-day offset.
-function toOccurrenceKey(date: Date): Date {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-  );
-}
-
 // Confirms the bill exists and belongs to the requesting user before a payment
-// is attached to it — mirrors the ownership check in the bill router.
+// is attached to it — mirrors the ownership check in the bill router. Returns the
+// resolved ids so callers don't re-parse them.
 async function assertBillOwned(
   ctx: { db: Db; session: { user: { id: string } } },
   billId: string,
-): Promise<ObjectId> {
+): Promise<{ billOid: ObjectId; userOid: ObjectId }> {
   if (!ObjectId.isValid(billId)) {
     throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
   }
@@ -55,7 +47,7 @@ async function assertBillOwned(
     throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
   }
 
-  return billOid;
+  return { billOid, userOid };
 }
 
 export const paymentRouter = createTRPCRouter({
@@ -71,19 +63,15 @@ export const paymentRouter = createTRPCRouter({
   markPaid: protectedProcedure
     .input(z.object({ billId: z.string(), occurrenceDate: z.date() }))
     .mutation(async ({ ctx, input }) => {
-      const billOid = await assertBillOwned(ctx, input.billId);
-      const occurrenceDate = toOccurrenceKey(input.occurrenceDate);
+      const { billOid, userOid } = await assertBillOwned(ctx, input.billId);
+      const occurrenceDate = truncateToUtcDateOnly(input.occurrenceDate);
 
       // Upsert on the (userId, billId, occurrenceDate) identity so re-marking the
       // same occurrence refreshes paidAt rather than adding a row. Without a
       // unique index, truly concurrent upserts can still race to insert
       // duplicates — deferred; markUnpaid's deleteMany clears any that appear.
       await ctx.db.collection<WithoutId<PaymentDoc>>("payments").updateOne(
-        {
-          userId: new ObjectId(ctx.session.user.id),
-          billId: billOid,
-          occurrenceDate,
-        },
+        { userId: userOid, billId: billOid, occurrenceDate },
         { $set: { paidAt: new Date() } },
         { upsert: true },
       );
@@ -91,14 +79,14 @@ export const paymentRouter = createTRPCRouter({
   markUnpaid: protectedProcedure
     .input(z.object({ billId: z.string(), occurrenceDate: z.date() }))
     .mutation(async ({ ctx, input }) => {
-      const billOid = await assertBillOwned(ctx, input.billId);
+      const { billOid, userOid } = await assertBillOwned(ctx, input.billId);
 
       // deleteMany (not deleteOne) self-heals any duplicate a concurrent
       // upsert race may have created, so unmarking always fully clears it.
       await ctx.db.collection<PaymentDoc>("payments").deleteMany({
-        userId: new ObjectId(ctx.session.user.id),
+        userId: userOid,
         billId: billOid,
-        occurrenceDate: toOccurrenceKey(input.occurrenceDate),
+        occurrenceDate: truncateToUtcDateOnly(input.occurrenceDate),
       });
     }),
 });

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -1,0 +1,112 @@
+import { TRPCError } from "@trpc/server";
+import { ObjectId, type Db, type WithoutId } from "mongodb";
+import { z } from "zod";
+import type { Payment as SerializedPayment } from "~/types";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+// A payment marks one *occurrence* of a bill as settled. Occurrences aren't
+// stored rows — they're generated on the fly from the bill's recurrence rule —
+// so a payment stands alone, identified by the (billId, occurrenceDate) pair.
+// The set is sparse: only paid occurrences have a document; absence = unpaid.
+type PaymentDoc = {
+  _id: ObjectId;
+  userId: ObjectId;
+  billId: ObjectId;
+  occurrenceDate: Date;
+  amountPaid?: number;
+  paidAt: Date;
+};
+
+function serializePayment(payment: PaymentDoc): SerializedPayment {
+  return {
+    ...payment,
+    _id: payment._id.toHexString(),
+    userId: payment.userId.toHexString(),
+    billId: payment.billId.toHexString(),
+  };
+}
+
+// Truncate an occurrence instant to UTC midnight of its calendar day, so the
+// stored key sits in the same UTC-naive frame the scheduler generates
+// occurrences in (see date-utils.ts). Without this a paid marker could miss its
+// occurrence by a sub-day offset.
+function toOccurrenceKey(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+// Confirms the bill exists and belongs to the requesting user before a payment
+// is attached to it — mirrors the ownership check in the bill router.
+async function assertBillOwned(
+  ctx: { db: Db; session: { user: { id: string } } },
+  billId: string,
+): Promise<ObjectId> {
+  if (!ObjectId.isValid(billId)) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
+  }
+
+  const billOid = new ObjectId(billId);
+  const userOid = new ObjectId(ctx.session.user.id);
+  const found = await ctx.db
+    .collection("bills")
+    .findOne({ _id: billOid, userId: userOid }, { projection: { _id: 1 } });
+
+  if (!found) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
+  }
+
+  return billOid;
+}
+
+export const paymentRouter = createTRPCRouter({
+  getAll: protectedProcedure.query(async ({ ctx }) => {
+    const cursor = ctx.db
+      .collection<PaymentDoc>("payments")
+      .find({ userId: new ObjectId(ctx.session.user.id) });
+    const payments = await cursor.toArray();
+    await cursor.close();
+
+    return payments.map(serializePayment);
+  }),
+  markPaid: protectedProcedure
+    .input(
+      z.object({
+        billId: z.string(),
+        occurrenceDate: z.date(),
+        amountPaid: z.number().min(0).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const billOid = await assertBillOwned(ctx, input.billId);
+      const occurrenceDate = toOccurrenceKey(input.occurrenceDate);
+
+      // Upsert on the (userId, billId, occurrenceDate) identity so marking the
+      // same occurrence paid twice refreshes paidAt instead of duplicating.
+      const set: Record<string, unknown> = { paidAt: new Date() };
+      if (input.amountPaid != null) set.amountPaid = input.amountPaid;
+
+      await ctx.db.collection<WithoutId<PaymentDoc>>("payments").updateOne(
+        {
+          userId: new ObjectId(ctx.session.user.id),
+          billId: billOid,
+          occurrenceDate,
+        },
+        { $set: set },
+        { upsert: true },
+      );
+    }),
+  markUnpaid: protectedProcedure
+    .input(z.object({ billId: z.string(), occurrenceDate: z.date() }))
+    .mutation(async ({ ctx, input }) => {
+      const billOid = await assertBillOwned(ctx, input.billId);
+
+      // deleteMany (not deleteOne) self-heals any duplicate a concurrent
+      // upsert race may have created, so unmarking always fully clears it.
+      await ctx.db.collection<PaymentDoc>("payments").deleteMany({
+        userId: new ObjectId(ctx.session.user.id),
+        billId: billOid,
+        occurrenceDate: toOccurrenceKey(input.occurrenceDate),
+      });
+    }),
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,3 +49,14 @@ export interface Group {
   name: string;
   order: number;
 }
+
+// A settled occurrence of a bill. `occurrenceDate` is the UTC-midnight day-key
+// that lines up with a scheduler-generated occurrence (see date-utils.ts).
+export interface Payment {
+  _id: string;
+  userId: string;
+  billId: string;
+  occurrenceDate: Date;
+  amountPaid?: number;
+  paidAt: Date;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,5 @@ export interface Payment {
   userId: string;
   billId: string;
   occurrenceDate: Date;
-  amountPaid?: number;
   paidAt: Date;
 }


### PR DESCRIPTION
## Summary

Implements **#34** — mark bill occurrences as paid, with the dashboard reflecting what's still owed.

Occurrences are generated client-side from recurrence rules, so paid-state lives in a sparse **`payments`** collection keyed by `(userId, billId, occurrenceDate)` and is joined to occurrences in memory. A row checkbox on the dashboard toggles idempotent `markPaid` / `markUnpaid` tRPC mutations; paid rows render dimmed with a struck-through amount.

Closes #34.

## What's included

- **`payments` collection + `paymentRouter`** (`getAll`, `markPaid` upsert, `markUnpaid` `deleteMany`), wired into the app router.
- **`payment-utils.ts`** — the occurrence↔payment join (UTC-midnight-stable composite key + `Set` lookup).
- **Bill list** — per-occurrence paid checkbox, dim/strike, disabled-through-refetch toggle.
- **Summary cards** — a **"Remaining"** card (unpaid total, shrinks toward ₱0) and **Next Bill** skips paid occurrences.

## Design decisions

- **Approach A** (separate `payments` collection + client join) over embedding on the bill doc (write-contention, unbounded growth) or server-side occurrence expansion (a large architectural inversion).
- **Balance semantics — "Remaining to pay":** the summary card shows the *unpaid* total (no income term), while the per-period cards keep their stable `income − all-bills` projection with paid shown only as a struck row. This is the coherent choice — an income-relative balance is paid-invariant, so "what's left to pay" must be its own number. (See the design spec's post-review revision note.)

## Code review (xhigh) — addressed in this PR

- Balance math was incoherent (excluding paid from outgoing without crediting income inflated the balance / flipped short→ahead) → reworked to remaining-to-pay, per above.
- Stale-cache toggle race → keep the row disabled through the refetch, not just the mutation response.
- Duplicate React keys for multi-occurrence bills → key rows by the per-occurrence key.
- Orphaned payments on bill delete → `bill.delete` now cascades to `payments`.
- Client/server occurrence-key asymmetry → client key truncates to UTC midnight, matching the server.
- Dropped the unused `amountPaid` input (deferred per spec).

## Deferred follow-ups

- #39 — unique index on the `payments` identity (concurrent-upsert dedup)
- #40 — bound `payment.getAll` to the visible pay-period window
- #41 — re-key/clear payments when a bill's schedule is edited

## Verification

No test framework in this repo (per CLAUDE.md). `pnpm typecheck` + `eslint` clean on all changed files; `SKIP_ENV_VALIDATION=1 pnpm build` passes. Verified live in-browser: single + recurring bills, mark/reload/unmark, per-occurrence isolation, the remaining-to-pay behavior (Remaining ₱→₀ while the per-period card stays paid-invariant), and 0 console errors.

## Design docs

- `docs/superpowers/specs/2026-07-04-mark-bill-occurrences-paid-design.md`
- `docs/superpowers/plans/2026-07-04-mark-bill-occurrences-paid.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
