### PR TITLE
fix: add unique payment occurrence index

### DIFF
--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -67,9 +67,9 @@ export const paymentRouter = createTRPCRouter({
       const occurrenceDate = truncateToUtcDateOnly(input.occurrenceDate);
 
       // Upsert on the (userId, billId, occurrenceDate) identity so re-marking the
-      // same occurrence refreshes paidAt rather than adding a row. Without a
-      // unique index, truly concurrent upserts can still race to insert
-      // duplicates — deferred; markUnpaid's deleteMany clears any that appear.
+      // same occurrence refreshes paidAt rather than adding a row. The payments
+      // collection has a unique compound index for this identity; markUnpaid uses
+      // deleteMany as a defensive cleanup for any historical duplicates.
       await ctx.db.collection<WithoutId<PaymentDoc>>("payments").updateOne(
         { userId: userOid, billId: billOid, occurrenceDate },
         { $set: { paidAt: new Date() } },

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -11,6 +11,7 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 import { auth } from "~/server/auth";
 import { db } from "../db";
+import { ensureDatabaseIndexes } from "../db/indexes";
 
 /**
  * 1. CONTEXT
@@ -25,6 +26,8 @@ import { db } from "../db";
  * @see https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
+  await ensureDatabaseIndexes(db);
+
   const session = await auth.api.getSession({
     headers: opts.headers,
   });

--- a/src/server/db/indexes.ts
+++ b/src/server/db/indexes.ts
@@ -1,0 +1,28 @@
+import type { Db } from "mongodb";
+
+let databaseIndexesPromise: Promise<void> | undefined;
+
+async function createDatabaseIndexes(db: Db): Promise<void> {
+  await db.collection("payments").createIndex(
+    { userId: 1, billId: 1, occurrenceDate: 1 },
+    {
+      name: "payments_user_bill_occurrence_unique",
+      unique: true,
+    },
+  );
+}
+
+/**
+ * Ensures application-level MongoDB indexes exist.
+ *
+ * MongoDB index creation is idempotent when the name/spec/options match, and the
+ * module-level promise keeps concurrent first requests from racing to create the
+ * same index repeatedly.
+ */
+export function ensureDatabaseIndexes(db: Db): Promise<void> {
+  databaseIndexesPromise ??= createDatabaseIndexes(db).catch((error: unknown) => {
+    databaseIndexesPromise = undefined;
+    throw error;
+  });
+  return databaseIndexesPromise;
+}


### PR DESCRIPTION
## Summary
- Add an idempotent MongoDB index initializer for application indexes
- Create a unique compound payments index on `userId, billId, occurrenceDate`
- Run index initialization once from tRPC context before handling API requests
- Update payment upsert comment now that the unique index exists

Closes #39

## Test Plan
- [x] `corepack pnpm typecheck`
- [x] `node_modules/.bin/eslint src/server/db/indexes.ts src/server/api/trpc.ts src/server/api/routers/payment.ts`
- [x] `MONGODB_URI='mongodb://127.0.0.1:27017/main' AUTH_GOOGLE_ID='dummy' AUTH_GOOGLE_SECRET='dummy' BETTER_AUTH_SECRET='dummysecretdummysecretdummysecret12' BETTER_AUTH_URL='http://localhost:3000' corepack pnpm build`
