### PR TITLE
feat: BNPL accounts with consolidated monthly statements (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,18 @@ pnpm format:check     # Prettier check
 pnpm format:write     # Prettier auto-format
 ```
 
-No test framework is configured.
+```bash
+pnpm test             # Vitest run (pure helpers in `src/**/*.test.ts`)
+pnpm test:watch       # Vitest watch mode
+```
+
+Vitest covers pure helpers only — there is no harness for tRPC routers or
+components, so router logic is verified by review and by hand.
 
 ## Architecture
 
 ### Tech Stack
+
 - **Framework:** Next.js 16 (App Router, RSC)
 - **Language:** TypeScript (strict mode), path alias `~/` → `src/`
 - **API:** tRPC 11 with SuperJSON transformer — type-safe end-to-end RPC
@@ -35,8 +42,9 @@ No test framework is configured.
 - **Env validation:** `@t3-oss/env-nextjs` in `src/env.js`
 
 ### Key Directories
+
 - `src/app/` — Next.js App Router pages and layouts
-- `src/server/api/routers/` — tRPC routers (`bill`, `income`, `post`)
+- `src/server/api/routers/` — tRPC routers (`bill`, `bnpl`, `group`, `income`, `payment`, `post`)
 - `src/server/api/trpc.ts` — tRPC initialization, context, `publicProcedure`/`protectedProcedure`
 - `src/server/api/root.ts` — tRPC app router combining all sub-routers
 - `src/server/auth/` — Better Auth configuration
@@ -50,13 +58,16 @@ No test framework is configured.
 - `src/lib/bill-utils.ts` — Recurrence helpers using rrule (pay rules, bill scheduling)
 
 ### Routes
+
 - `/` — Home/landing page
 - `/dashboard` — Main bill dashboard (protected)
-- `/bills` — Bill list (protected)
 - `/bills/create` — Create bill form (protected)
+- `/groups` — Bill group management (protected)
+- `/bnpl` — BNPL account management: accounts, purchases, statement settling (protected)
 - `/playground` — Guest-accessible demo area with local-only bill state
 
 ### API Pattern (tRPC)
+
 - Routers live in `src/server/api/routers/`. Each exports a router created with `createTRPCRouter`.
 - Use `protectedProcedure` for authenticated endpoints; it guarantees `ctx.session.user` is non-null.
 - Use `publicProcedure` for unauthenticated endpoints.
@@ -65,14 +76,17 @@ No test framework is configured.
 - Server calls (RSC): use the caller from `src/trpc/server.ts`.
 
 ### Auth
+
 - Better Auth configured in `src/server/auth/config.ts` with MongoDB adapter.
 - Providers: Google OAuth, anonymous sign-in (guest mode).
-- Route protection via Next.js middleware in `src/proxy.ts` — checks session for `/dashboard`. Uses optimistic redirect (not fully secure per Better Auth docs) — handle auth checks in individual pages too.
+- Route protection via Next.js middleware in `src/proxy.ts` — checks session for `/dashboard`, `/playground`, `/groups`, and `/bnpl`. Uses optimistic redirect (not fully secure per Better Auth docs) — handle auth checks in individual pages too.
 - Client auth: `src/lib/auth-client.ts` exports `authClient` with `signIn`, `signOut`, `useSession`.
 
 ### Forms & Validation
+
 - React Hook Form with Zod schemas. Use `useWatch` (not `form.watch`) for reactive field watching.
 - Bill creation uses a Zod discriminated union: single bills (with `date`) vs recurring bills (with `recurrence` using rrule).
 
 ### Environment Variables
+
 Required: `MONGODB_URI`, `BETTER_AUTH_URL`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`. `BETTER_AUTH_SECRET` is required in production. Set `SKIP_ENV_VALIDATION=1` to bypass validation (useful for Docker builds).

--- a/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
+++ b/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
@@ -969,6 +969,44 @@ export const bnplRouter = createTRPCRouter({
       if (ops.length > 0) {
         await ctx.db.collection("bills").bulkWrite(ops);
       }
+
+      // Paid-markers are keyed on (billId, occurrenceDate), so moving dtstart
+      // moves the occurrences they point at. Left alone, every paid installment
+      // would revert to unpaid and the stale rows could never be cleared —
+      // markUnpaid needs the occurrence rendered before it can be clicked.
+      // Shift them by the same transform: month kept, day replaced. A bill has
+      // at most one occurrence per month, so two markers for one bill always
+      // differ in month and cannot collide on the new date.
+      const billOids = purchases.map((p) => p._id);
+      if (billOids.length > 0) {
+        const markerCursor = ctx.db
+          .collection<{
+            _id: ObjectId;
+            billId: ObjectId;
+            occurrenceDate: Date;
+          }>("payments")
+          .find({ userId: userOid, billId: { $in: billOids } });
+        const markers = await markerCursor.toArray();
+        await markerCursor.close();
+
+        const markerOps = markers.map((marker) => ({
+          updateOne: {
+            filter: { _id: marker._id, userId: userOid },
+            update: {
+              $set: {
+                occurrenceDate: deriveStatementDtstart(
+                  nextDueDay,
+                  marker.occurrenceDate,
+                ),
+              },
+            },
+          },
+        }));
+
+        if (markerOps.length > 0) {
+          await ctx.db.collection("payments").bulkWrite(markerOps);
+        }
+      }
     }),
 
   delete: protectedProcedure
@@ -1291,11 +1329,17 @@ async function assertPurchasesInAccount(
 ): Promise<{ billOids: ObjectId[]; userOid: ObjectId }> {
   const { accountOid, userOid } = await assertAccountOwned(ctx, accountId);
 
-  if (billIds.some((id) => !ObjectId.isValid(id))) {
+  // Dedupe before counting: `countDocuments` counts distinct documents, so a
+  // repeated id would make `matched` fall short of the raw input length and
+  // reject a request whose every id is validly owned. The deduped set is also
+  // what the callers write from, so bulkWrite emits no redundant ops.
+  const uniqueIds = [...new Set(billIds)];
+
+  if (uniqueIds.some((id) => !ObjectId.isValid(id))) {
     throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
   }
 
-  const billOids = billIds.map((id) => new ObjectId(id));
+  const billOids = uniqueIds.map((id) => new ObjectId(id));
   const matched = await ctx.db.collection("bills").countDocuments({
     _id: { $in: billOids },
     userId: userOid,
@@ -2622,8 +2666,12 @@ In `BillListCard`, accept `accounts: BnplAccount[]` in its props, then split the
 `outgoing` must keep summing **all** rows — installments included — so the balance stays an honest projection:
 
 ```tsx
-  // Installments are counted here but itemized as one roll-up row per account
-  // below, so section subtotals plus statement amounts still equal `outgoing`.
+  // Two things deliberately stay in this sum. Paid occurrences, because the card
+  // balance is a stable income-minus-all-bills projection rather than "cash
+  // left" — paid shows as a struck row, and remaining-to-pay lives in the
+  // summary cards. And installments, because they are itemized as one roll-up
+  // row per account below, so section subtotals plus statement amounts still
+  // equal `outgoing`.
   const outgoing = useMemo(
     () =>
       sumBy(
@@ -2734,10 +2782,10 @@ Rework the `useMemo` so "Total Bills" and "Next Bill" treat a statement as one i
   const { remaining, nextItem, billCount } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
     const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
-    if (!currentPay) return { remaining: 0, nextItem: null, billCount: 0 };
+    if (!currentPay) return { remaining: 0, nextItem: null };
 
     const nextPayDate = payRule.after(currentPay);
-    if (!nextPayDate) return { remaining: 0, nextItem: null, billCount: 0 };
+    if (!nextPayDate) return { remaining: 0, nextItem: null };
 
     const periodRows = computeBillsInPeriod(bills, currentPay, nextPayDate);
     const { bills: ordinaryRows, installments } = partitionBills(periodRows);
@@ -2752,14 +2800,6 @@ Rework the `useMemo` so "Total Bills" and "Next Bill" treat a statement as one i
       s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date))
         ? 0
         : s.amount,
-    );
-
-    // "Total Bills" counts a statement as one obligation, not N purchases —
-    // one payment is what the user actually makes.
-    const { bills: ordinaryAll, installments: installmentsAll } =
-      partitionBills(bills);
-    const accountsWithPurchases = new Set(
-      installmentsAll.map((b) => b.bnplAccountId),
     );
 
     // Nearest upcoming unpaid obligation of either kind.
@@ -2788,9 +2828,21 @@ Rework the `useMemo` so "Total Bills" and "Next Bill" treat a statement as one i
     return {
       remaining: remainingBills + remainingStatements,
       nextItem: candidates[0] ?? null,
-      billCount: ordinaryAll.length + accountsWithPurchases.size,
     };
   }, [incomeProfile, bills, paidKeys, accounts]);
+
+  // Counted independently of the pay period. A statement is one obligation
+  // whenever it falls, and this card has always been whole-list ("Active
+  // bills"). Deriving it inside the period memo above would make it read 0
+  // whenever no current pay period resolves — e.g. a profile whose start date
+  // is still in the future, which is exactly a new user's first days.
+  const billCount = useMemo(() => {
+    const { bills: ordinaryAll, installments } = partitionBills(bills);
+    const accountsWithPurchases = new Set(
+      installments.map((b) => b.bnplAccountId),
+    );
+    return ordinaryAll.length + accountsWithPurchases.size;
+  }, [bills]);
 ```
 
 Update the two affected cards:
@@ -2871,4 +2923,5 @@ git commit -m "feat: count BNPL statements in summary cards, exclude from playgr
 - Section subtotals plus roll-up amounts equal each period card's outgoing total.
 - Changing an account's due day moves every existing purchase, leaving exactly one statement per month.
 - Deleting an account offers both outcomes: "delete purchases too" removes them and their paid-markers; "keep as ordinary bills" leaves them in the bill list with their paid history intact.
+- Changing an account's due day preserves paid state: markers move with their occurrences rather than being stranded on dates nothing renders.
 - No file in `src/` contains the string "Shopee" or "SPayLater" outside of placeholder/example copy.

--- a/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
+++ b/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
@@ -1,0 +1,2754 @@
+# BNPL Accounts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Manage buy-now-pay-later purchases on a dedicated `/bnpl` page, grouped under provider accounts, so their installments leave the pay-period bill list while their money stays in the dashboard's totals.
+
+**Architecture:** A BNPL purchase is stored as an ordinary `bills` document carrying a new optional `bnplAccountId`. Presence of that field is the only discriminator, so no migration is needed and the existing scheduler, occurrence generator, and `payments` join are reused verbatim. Provider accounts live in a new `bnpl_accounts` collection and own the shared monthly `dueDay`; each purchase's `dtstart` is derived server-side from that day, which makes a split statement unrepresentable. The dashboard partitions bills at render time and shows one roll-up row per account per period.
+
+**Tech Stack:** Next.js 16 (App Router), tRPC 11, MongoDB native driver, Zod 4, React Hook Form, Shadcn/ui, Tailwind 4, date-fns, rrule, Vitest (introduced by this plan).
+
+**Spec:** `docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md`
+
+## Global Constraints
+
+- Path alias `~/` maps to `src/`. Use it for cross-directory imports.
+- TypeScript is strict, with `noUncheckedIndexedAccess` (array/index access yields `T | undefined` — handle it) and `verbatimModuleSyntax` (type-only imports MUST use `import type`).
+- Date-only values are canonical **UTC midnight**. Build them with `Date.UTC(...)`, format them with `formatUtcDate`, and floor them with `truncateToUtcDateOnly`. Never use local-time constructors for a stored date.
+- Currency is PHP, rendered via `toLocaleString("en-PH", { style: "currency", currency: "PHP" })`.
+- `pnpm check` and `pnpm lint` are unreliable under Next 16 (`next lint` was removed). Verify with `pnpm exec tsc --noEmit` and `pnpm exec eslint <paths>` directly.
+- Package manager is **pnpm**.
+- New tRPC routers must be registered in `src/server/api/root.ts`.
+- No identifier, label, or comment in the codebase may name a specific provider (no "Shopee", no "SPayLater"). Providers are user-created account rows.
+- Every mutation is a `protectedProcedure` and must scope its query by `userId`.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+| --- | --- |
+| `vitest.config.ts` | Vitest config with the `~` alias |
+| `src/lib/bnpl-utils.ts` | Pure BNPL logic: dtstart derivation, statement grouping, installment progress |
+| `src/lib/bnpl-utils.test.ts` | Tests for the above |
+| `src/lib/bill-utils.test.ts` | Tests for `partitionBills` |
+| `src/schemas/bnpl.ts` | Zod input schemas |
+| `src/server/api/bill-cascade.ts` | Shared "delete bills + their payments" cascade |
+| `src/server/api/routers/bnpl.ts` | Account CRUD + purchase mutations |
+| `src/app/bnpl/page.tsx` | RSC shell |
+| `src/components/bnplManager.tsx` | Account list, empty state, orchestration |
+| `src/components/bnplAccountCard.tsx` | One account: statement, paid toggle, purchases |
+| `src/components/bnplAccountFormDialog.tsx` | Create/edit account |
+| `src/components/bnplPurchaseFormDialog.tsx` | Create/edit purchase |
+
+**Modified:**
+
+| File | Change |
+| --- | --- |
+| `package.json` | Add `vitest` dev dep, `test` scripts |
+| `src/types/index.ts` | Add `BnplAccount`; add `bnplAccountId` to `BillEvent` |
+| `src/lib/bill-utils.ts` | Add `partitionBills` |
+| `src/server/api/routers/bill.ts` | `delete` uses the shared cascade |
+| `src/server/api/routers/payment.ts` | Add statement-level paid mutations |
+| `src/server/api/root.ts` | Register `bnplRouter` |
+| `src/components/authenticatedLayout.tsx` | Add the BNPL nav link |
+| `src/app/_components/billList.tsx` | Partition; render roll-up rows |
+| `src/components/financialSummaryCards.tsx` | Partition; statement counts as 1 |
+| `src/components/playgroundStartScreen.tsx` | Clone only ordinary bills |
+
+---
+
+## Task 1: Vitest setup and `dtstart` derivation
+
+**Files:**
+- Create: `vitest.config.ts`
+- Create: `src/lib/bnpl-utils.ts`
+- Test: `src/lib/bnpl-utils.test.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `deriveStatementDtstart(dueDay: number, firstDueMonth: Date): Date` — the first statement date for a purchase, at UTC midnight, clamped back to month end. Tasks 4 and 5 call it.
+
+- [ ] **Step 1: Install Vitest**
+
+```bash
+pnpm add -D vitest
+```
+
+- [ ] **Step 2: Add the Vitest config**
+
+Create `vitest.config.ts`. The alias mirrors the `~/*` path in `tsconfig.json` so tests can import project modules; declaring it manually avoids adding a tsconfig-paths plugin.
+
+```ts
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 3: Add test scripts**
+
+In `package.json`, add to `"scripts"`:
+
+```json
+    "test": "vitest run",
+    "test:watch": "vitest",
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `src/lib/bnpl-utils.test.ts`. Vitest globals are not enabled, so the helpers are imported explicitly.
+
+```ts
+import { describe, expect, it } from "vitest";
+import { deriveStatementDtstart } from "~/lib/bnpl-utils";
+
+// Helper: a UTC-midnight date, for readable expectations.
+const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d));
+
+describe("deriveStatementDtstart", () => {
+  it("uses the account's due day in the chosen month", () => {
+    expect(deriveStatementDtstart(15, utc(2026, 9, 1))).toEqual(utc(2026, 9, 15));
+  });
+
+  it("ignores the day component of firstDueMonth", () => {
+    // Only the year and month of the input matter; the day comes from dueDay.
+    expect(deriveStatementDtstart(5, utc(2026, 9, 28))).toEqual(utc(2026, 9, 5));
+  });
+
+  it("clamps day 31 back to the end of a short month", () => {
+    expect(deriveStatementDtstart(31, utc(2026, 2, 1))).toEqual(utc(2026, 2, 28));
+    expect(deriveStatementDtstart(31, utc(2026, 4, 1))).toEqual(utc(2026, 4, 30));
+  });
+
+  it("clamps to Feb 29 in a leap year", () => {
+    expect(deriveStatementDtstart(31, utc(2028, 2, 1))).toEqual(utc(2028, 2, 29));
+  });
+
+  it("leaves day 28 untouched in every month", () => {
+    for (let month = 1; month <= 12; month++) {
+      expect(deriveStatementDtstart(28, utc(2026, month, 1))).toEqual(
+        utc(2026, month, 28),
+      );
+    }
+  });
+
+  it("returns exact UTC midnight", () => {
+    const result = deriveStatementDtstart(15, utc(2026, 9, 1));
+    expect(result.getUTCHours()).toBe(0);
+    expect(result.getTime() % 86_400_000).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `pnpm test`
+Expected: FAIL — cannot resolve `~/lib/bnpl-utils`.
+
+- [ ] **Step 6: Write the implementation**
+
+Create `src/lib/bnpl-utils.ts`:
+
+```ts
+// Pure BNPL logic. A BNPL provider consolidates: every active purchase's
+// installment for the month lands on one statement, with one due date and one
+// payment. That invariant is enforced here — the account owns the day-of-month,
+// and a purchase's schedule is derived from it rather than supplied alongside
+// it, so a split statement can't be constructed.
+
+/** Last day of the given UTC month (`month` is 0-indexed). */
+function lastDayOfUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+/**
+ * First statement date for a purchase: the account's `dueDay` placed in the
+ * month of `firstDueMonth`, at canonical UTC midnight.
+ *
+ * A `dueDay` of 29–31 doesn't exist in every month, so it clamps *backward* to
+ * that month's last day — day 31 in February yields Feb 28 (Feb 29 in a leap
+ * year). Rolling forward instead would push the statement into the wrong month
+ * and skip the intended one. This matches the clamping that
+ * `monthlyOccurrencesInPeriod` applies to every occurrence *after* the first;
+ * doing it here keeps the anchor in the same frame as the series it seeds.
+ *
+ * Only the year and month of `firstDueMonth` are read — its day is irrelevant,
+ * since the day always comes from the account.
+ */
+export function deriveStatementDtstart(
+  dueDay: number,
+  firstDueMonth: Date,
+): Date {
+  const year = firstDueMonth.getUTCFullYear();
+  const month = firstDueMonth.getUTCMonth();
+  const day = Math.min(dueDay, lastDayOfUtcMonth(year, month));
+  return new Date(Date.UTC(year, month, day));
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 8: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/lib/bnpl-utils.ts src/lib/bnpl-utils.test.ts vitest.config.ts
+```
+
+Expected: both clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml vitest.config.ts src/lib/bnpl-utils.ts src/lib/bnpl-utils.test.ts
+git commit -m "feat: add Vitest and BNPL statement dtstart derivation (#44)"
+```
+
+---
+
+## Task 2: `partitionBills`
+
+**Files:**
+- Modify: `src/lib/bill-utils.ts`
+- Modify: `src/types/index.ts`
+- Test: `src/lib/bill-utils.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `BillEvent` gains `bnplAccountId?: string | null`.
+  - `partitionBills<T extends { bnplAccountId?: string | null }>(rows: T[]): { bills: T[]; installments: T[] }` — used by Tasks 9 and 10.
+
+- [ ] **Step 1: Add `bnplAccountId` to `BillEvent`**
+
+In `src/types/index.ts`, extend the `BillEvent` type. It currently reads:
+
+```ts
+export type BillEvent = {
+  _id: string;
+  title: string;
+  amount?: number;
+  userId: string;
+  groupId?: string | null;
+} & (Single | Recurring);
+```
+
+Add the field with a comment explaining the discriminator:
+
+```ts
+export type BillEvent = {
+  _id: string;
+  title: string;
+  amount?: number;
+  userId: string;
+  groupId?: string | null;
+  // Present = this bill is a BNPL installment purchase, and names the account
+  // it belongs to. Absent = an ordinary bill. Presence is the only
+  // discriminator, which is why no migration was needed to introduce it.
+  bnplAccountId?: string | null;
+} & (Single | Recurring);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/lib/bill-utils.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { partitionBills } from "~/lib/bill-utils";
+
+describe("partitionBills", () => {
+  it("splits installments from ordinary bills", () => {
+    const rows = [
+      { _id: "a" },
+      { _id: "b", bnplAccountId: "acc1" },
+      { _id: "c", bnplAccountId: null },
+      { _id: "d", bnplAccountId: "acc2" },
+    ];
+
+    const { bills, installments } = partitionBills(rows);
+
+    expect(bills.map((b) => b._id)).toEqual(["a", "c"]);
+    expect(installments.map((b) => b._id)).toEqual(["b", "d"]);
+  });
+
+  it("treats an empty-string account id as an ordinary bill", () => {
+    // Defensive: an empty string is not a usable ObjectId, so it must not be
+    // routed into the installment bucket where it would be grouped by a
+    // meaningless key.
+    const { bills, installments } = partitionBills([
+      { _id: "a", bnplAccountId: "" },
+    ]);
+
+    expect(bills.map((b) => b._id)).toEqual(["a"]);
+    expect(installments).toEqual([]);
+  });
+
+  it("preserves input order within each bucket", () => {
+    const rows = [
+      { _id: "1", bnplAccountId: "x" },
+      { _id: "2" },
+      { _id: "3", bnplAccountId: "x" },
+      { _id: "4" },
+    ];
+
+    const { bills, installments } = partitionBills(rows);
+
+    expect(bills.map((b) => b._id)).toEqual(["2", "4"]);
+    expect(installments.map((b) => b._id)).toEqual(["1", "3"]);
+  });
+
+  it("returns two empty buckets for empty input", () => {
+    expect(partitionBills([])).toEqual({ bills: [], installments: [] });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm test src/lib/bill-utils.test.ts`
+Expected: FAIL — `partitionBills` is not exported.
+
+- [ ] **Step 4: Write the implementation**
+
+Append to `src/lib/bill-utils.ts`:
+
+```ts
+/**
+ * Split rows into ordinary bills and BNPL installments.
+ *
+ * BNPL purchases share the `bills` collection, so `bill.getAll` returns both
+ * kinds. This is the single place that filter is spelled: a polymorphic
+ * collection rots when each call site writes its own predicate, and a missed
+ * one leaks installments back into a list as individual rows — the exact
+ * clutter the BNPL feature removes.
+ *
+ * Generic over the element type because two shapes need it: raw `BillEvent`s
+ * (the summary cards) and generated occurrence rows (`BillEvent & { date: Date }`,
+ * the bill list).
+ */
+export function partitionBills<T extends { bnplAccountId?: string | null }>(
+  rows: T[],
+): { bills: T[]; installments: T[] } {
+  const bills: T[] = [];
+  const installments: T[] = [];
+
+  for (const row of rows) {
+    if (row.bnplAccountId) {
+      installments.push(row);
+    } else {
+      bills.push(row);
+    }
+  }
+
+  return { bills, installments };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm test`
+Expected: PASS — all tests from Tasks 1 and 2.
+
+- [ ] **Step 6: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/lib/bill-utils.ts src/lib/bill-utils.test.ts src/types/index.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/bill-utils.ts src/lib/bill-utils.test.ts src/types/index.ts
+git commit -m "feat: add partitionBills and bnplAccountId on BillEvent (#44)"
+```
+
+---
+
+## Task 3: Statement grouping and installment progress
+
+**Files:**
+- Modify: `src/lib/bnpl-utils.ts`
+- Modify: `src/lib/bnpl-utils.test.ts`
+- Modify: `src/types/index.ts`
+
+**Interfaces:**
+- Consumes: `deriveStatementDtstart` (Task 1), `truncateToUtcDateOnly` from `~/lib/date-utils`.
+- Produces:
+  - `BnplAccount` type: `{ _id: string; userId: string; name: string; dueDay: number }`.
+  - `Statement` type: `{ accountId: string; accountName: string; date: Date; amount: number; purchaseCount: number; billIds: string[] }`.
+  - `groupStatements(installments, accounts): Statement[]` — used by Tasks 8 and 9.
+  - `installmentProgress(dtstart: Date, count: number | undefined, asOf: Date): { elapsed: number; total: number }` — used by Task 8.
+
+- [ ] **Step 1: Add the `BnplAccount` type**
+
+Append to `src/types/index.ts`:
+
+```ts
+// A BNPL provider account (Shopee SPayLater, LazPayLater, …). The account owns
+// the shared monthly `dueDay`: every purchase under it derives its schedule from
+// that day, which is what makes one consolidated statement per month structural
+// rather than a data-entry convention.
+export interface BnplAccount {
+  _id: string;
+  userId: string;
+  name: string;
+  dueDay: number;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `src/lib/bnpl-utils.test.ts`. Note the imports at the top of the file must be extended to include `groupStatements` and `installmentProgress`.
+
+```ts
+import type { BnplAccount } from "~/types";
+import { groupStatements, installmentProgress } from "~/lib/bnpl-utils";
+
+const account = (id: string, name: string, dueDay = 15): BnplAccount => ({
+  _id: id,
+  userId: "u1",
+  name,
+  dueDay,
+});
+
+describe("groupStatements", () => {
+  it("sums one account's installments on the same date into one statement", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 1250, date: utc(2026, 9, 15) },
+        { _id: "b2", bnplAccountId: "a1", amount: 700, date: utc(2026, 9, 15) },
+        { _id: "b3", bnplAccountId: "a1", amount: 2250, date: utc(2026, 9, 15) },
+      ],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      accountId: "a1",
+      accountName: "SPayLater",
+      amount: 4200,
+      purchaseCount: 3,
+    });
+    expect(result[0]?.billIds).toEqual(["b1", "b2", "b3"]);
+  });
+
+  it("keeps different accounts as separate statements", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 1000, date: utc(2026, 9, 15) },
+        { _id: "b2", bnplAccountId: "a2", amount: 900, date: utc(2026, 9, 20) },
+      ],
+      [account("a1", "SPayLater"), account("a2", "LazPayLater", 20)],
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.accountName)).toEqual([
+      "SPayLater",
+      "LazPayLater",
+    ]);
+  });
+
+  it("sorts by date, then by account name", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a2", amount: 1, date: utc(2026, 9, 20) },
+        { _id: "b2", bnplAccountId: "a1", amount: 1, date: utc(2026, 9, 15) },
+        { _id: "b3", bnplAccountId: "a3", amount: 1, date: utc(2026, 9, 15) },
+      ],
+      [account("a1", "Bravo"), account("a2", "Alpha", 20), account("a3", "Alpha")],
+    );
+
+    expect(result.map((s) => [s.accountName, s.date.getUTCDate()])).toEqual([
+      ["Alpha", 15],
+      ["Bravo", 15],
+      ["Alpha", 20],
+    ]);
+  });
+
+  it("treats a missing amount as zero", () => {
+    const result = groupStatements(
+      [{ _id: "b1", bnplAccountId: "a1", date: utc(2026, 9, 15) }],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result[0]?.amount).toBe(0);
+    expect(result[0]?.purchaseCount).toBe(1);
+  });
+
+  it("keeps installments whose account is unknown, under a fallback name", () => {
+    // Money must never silently vanish from the roll-up: the period's outgoing
+    // total already includes this installment, so dropping it here would break
+    // the "subtotals sum to the balance" invariant the bill list documents.
+    const result = groupStatements(
+      [{ _id: "b1", bnplAccountId: "gone", amount: 500, date: utc(2026, 9, 15) }],
+      [],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ accountName: "BNPL", amount: 500 });
+  });
+
+  it("floors dates to their UTC day when grouping", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 100, date: utc(2026, 9, 15) },
+        {
+          _id: "b2",
+          bnplAccountId: "a1",
+          amount: 100,
+          date: new Date(Date.UTC(2026, 8, 15, 13, 30)),
+        },
+      ],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.amount).toBe(200);
+  });
+
+  it("returns nothing for no installments", () => {
+    expect(groupStatements([], [account("a1", "SPayLater")])).toEqual([]);
+  });
+});
+
+describe("installmentProgress", () => {
+  it("counts the first month as installment 1", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 9, 15))).toEqual({
+      elapsed: 1,
+      total: 6,
+    });
+  });
+
+  it("counts elapsed months inclusively", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 11, 15))).toEqual({
+      elapsed: 3,
+      total: 6,
+    });
+  });
+
+  it("counts across a year boundary", () => {
+    expect(installmentProgress(utc(2026, 11, 15), 6, utc(2027, 2, 15))).toEqual({
+      elapsed: 4,
+      total: 6,
+    });
+  });
+
+  it("never exceeds the total", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2028, 9, 15))).toEqual({
+      elapsed: 6,
+      total: 6,
+    });
+  });
+
+  it("reports zero before the first installment", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 8, 15))).toEqual({
+      elapsed: 0,
+      total: 6,
+    });
+  });
+
+  it("treats a missing count as a single installment", () => {
+    // A purchase always has a tenure, but `count` is optional on the shared
+    // recurrence type, so the fallback must be defined rather than NaN.
+    expect(installmentProgress(utc(2026, 9, 15), undefined, utc(2026, 9, 15)))
+      .toEqual({ elapsed: 1, total: 1 });
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm test src/lib/bnpl-utils.test.ts`
+Expected: FAIL — `groupStatements` and `installmentProgress` are not exported.
+
+- [ ] **Step 4: Write the implementation**
+
+Append to `src/lib/bnpl-utils.ts`:
+
+```ts
+import { truncateToUtcDateOnly } from "~/lib/date-utils";
+import type { BnplAccount } from "~/types";
+
+/** Shown when an installment references an account that no longer exists. */
+const UNKNOWN_ACCOUNT_NAME = "BNPL";
+
+/** One account's consolidated obligation on one date. */
+export interface Statement {
+  accountId: string;
+  accountName: string;
+  date: Date;
+  amount: number;
+  purchaseCount: number;
+  billIds: string[];
+}
+
+/** The shape `groupStatements` needs from a generated occurrence row. */
+interface InstallmentOccurrence {
+  _id: string;
+  bnplAccountId?: string | null;
+  amount?: number;
+  date: Date;
+}
+
+/**
+ * Collapse installment occurrences into one statement per (account, date).
+ *
+ * This is what a BNPL provider actually bills: not N separate purchases, but a
+ * single consolidated payment per account per month. The amount is derived
+ * rather than stored, so it shrinks on its own as purchases finish their tenure.
+ *
+ * An installment whose account has vanished is kept under a fallback name
+ * instead of being dropped. The enclosing period's outgoing total already counts
+ * it, so discarding it here would make the section subtotals stop summing to the
+ * balance — the same reasoning behind the bill list's "Ungrouped" catch-all.
+ */
+export function groupStatements(
+  installments: InstallmentOccurrence[],
+  accounts: BnplAccount[],
+): Statement[] {
+  const nameById = new Map(accounts.map((a) => [a._id, a.name]));
+  const byKey = new Map<string, Statement>();
+
+  for (const row of installments) {
+    const accountId = row.bnplAccountId;
+    if (!accountId) continue;
+
+    const date = truncateToUtcDateOnly(row.date);
+    const key = `${accountId}:${date.getTime()}`;
+
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.amount += row.amount ?? 0;
+      existing.purchaseCount += 1;
+      existing.billIds.push(row._id);
+      continue;
+    }
+
+    byKey.set(key, {
+      accountId,
+      accountName: nameById.get(accountId) ?? UNKNOWN_ACCOUNT_NAME,
+      date,
+      amount: row.amount ?? 0,
+      purchaseCount: 1,
+      billIds: [row._id],
+    });
+  }
+
+  return [...byKey.values()].sort(
+    (a, b) =>
+      a.date.getTime() - b.date.getTime() ||
+      a.accountName.localeCompare(b.accountName),
+  );
+}
+
+/**
+ * How far a purchase has advanced through its tenure as of a given statement
+ * date — the "3 of 6" on an account card.
+ *
+ * Counted inclusively from `dtstart`, so the first statement reads 1 of N, and
+ * clamped to `[0, total]` so a long-finished purchase reads N of N rather than
+ * drifting past it. Month arithmetic uses UTC fields to stay in the same frame
+ * as the stored anchor.
+ */
+export function installmentProgress(
+  dtstart: Date,
+  count: number | undefined,
+  asOf: Date,
+): { elapsed: number; total: number } {
+  const total = count ?? 1;
+  const monthsApart =
+    (asOf.getUTCFullYear() - dtstart.getUTCFullYear()) * 12 +
+    (asOf.getUTCMonth() - dtstart.getUTCMonth());
+  const elapsed = Math.min(Math.max(monthsApart + 1, 0), total);
+
+  return { elapsed, total };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm test`
+Expected: PASS — all tests from Tasks 1–3.
+
+- [ ] **Step 6: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/lib/bnpl-utils.ts src/lib/bnpl-utils.test.ts src/types/index.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/bnpl-utils.ts src/lib/bnpl-utils.test.ts src/types/index.ts
+git commit -m "feat: add BNPL statement grouping and installment progress (#44)"
+```
+
+---
+
+## Task 4: BNPL account router
+
+**Files:**
+- Create: `src/schemas/bnpl.ts`
+- Create: `src/server/api/routers/bnpl.ts`
+- Modify: `src/server/api/root.ts`
+
+**Interfaces:**
+- Consumes: `deriveStatementDtstart` (Task 1), `BnplAccount` (Task 3).
+- Produces:
+  - `bnpl.getAll` → `BnplAccount[]`, sorted by `_id`.
+  - `bnpl.create({ name, dueDay })` → `BnplAccount`.
+  - `bnpl.update({ id, data: { name?, dueDay? } })` → `void`.
+  - `bnpl.delete({ id })` → `void`.
+  - Exported from `bnpl.ts` for Task 5: `type BnplAccountDoc`, `assertAccountOwned(ctx, accountId)`.
+  - Zod schemas in `src/schemas/bnpl.ts`, extended in Task 5.
+
+- [ ] **Step 1: Write the account schemas**
+
+Create `src/schemas/bnpl.ts`, mirroring the style of `src/schemas/group.ts`:
+
+```ts
+import { z } from "zod";
+
+// `dueDay` accepts 1–31 even though short months lack 29–31. The day is clamped
+// backward when a statement date is derived (see `deriveStatementDtstart`), so
+// storing the user's intent verbatim is correct — rejecting 31 would stop them
+// modelling a real end-of-month cycle.
+const dueDaySchema = z.number().int().min(1).max(31);
+const accountNameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Name is required" })
+  .max(50);
+
+export const CreateBnplAccountInputSchema = z.object({
+  name: accountNameSchema,
+  dueDay: dueDaySchema,
+});
+
+export const UpdateBnplAccountInputSchema = z.object({
+  id: z.string(),
+  data: z.object({
+    name: accountNameSchema.optional(),
+    dueDay: dueDaySchema.optional(),
+  }),
+});
+
+export const DeleteBnplAccountInputSchema = z.object({ id: z.string() });
+
+export type CreateBnplAccountInput = z.infer<
+  typeof CreateBnplAccountInputSchema
+>;
+export type UpdateBnplAccountInput = z.infer<
+  typeof UpdateBnplAccountInputSchema
+>;
+```
+
+- [ ] **Step 2: Write the router**
+
+Create `src/server/api/routers/bnpl.ts`:
+
+```ts
+import { TRPCError } from "@trpc/server";
+import { ObjectId, type Db, type WithoutId } from "mongodb";
+import { deriveStatementDtstart } from "~/lib/bnpl-utils";
+import {
+  CreateBnplAccountInputSchema,
+  DeleteBnplAccountInputSchema,
+  UpdateBnplAccountInputSchema,
+} from "~/schemas/bnpl";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+// DB representation — ObjectId fields. See ~/types `BnplAccount` for the
+// domain shape.
+export type BnplAccountDoc = {
+  _id: ObjectId;
+  userId: ObjectId;
+  name: string;
+  dueDay: number;
+};
+
+// Minimal shape of a purchase document this router reads back when rewriting
+// schedules. Purchases are `bills` rows; see the bill router for the full type.
+type PurchaseDoc = {
+  _id: ObjectId;
+  recurrence?: { dtstart?: Date };
+};
+
+/**
+ * Confirms the account exists and belongs to the requesting user. Mirrors
+ * `resolveGroupId` in the bill router. Returns the resolved ids so callers
+ * don't re-parse them.
+ */
+export async function assertAccountOwned(
+  ctx: { db: Db; session: { user: { id: string } } },
+  accountId: string,
+): Promise<{ accountOid: ObjectId; userOid: ObjectId; dueDay: number }> {
+  if (!ObjectId.isValid(accountId)) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Account not found" });
+  }
+
+  const accountOid = new ObjectId(accountId);
+  const userOid = new ObjectId(ctx.session.user.id);
+  const found = await ctx.db
+    .collection<BnplAccountDoc>("bnpl_accounts")
+    .findOne(
+      { _id: accountOid, userId: userOid },
+      { projection: { dueDay: 1 } },
+    );
+
+  if (!found) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Account not found" });
+  }
+
+  return { accountOid, userOid, dueDay: found.dueDay };
+}
+
+export const bnplRouter = createTRPCRouter({
+  getAll: protectedProcedure.query(async ({ ctx }) => {
+    // Sorted by _id: ObjectIds are timestamp-prefixed, so this is a stable
+    // creation-order sort with no `order` field to write or keep consistent.
+    const cursor = ctx.db
+      .collection<BnplAccountDoc>("bnpl_accounts")
+      .find({ userId: new ObjectId(ctx.session.user.id) })
+      .sort({ _id: 1 });
+    const accounts = await cursor.toArray();
+    await cursor.close();
+
+    return accounts.map((a) => ({
+      _id: a._id.toHexString(),
+      userId: a.userId.toHexString(),
+      name: a.name,
+      dueDay: a.dueDay,
+    }));
+  }),
+
+  create: protectedProcedure
+    .input(CreateBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = new ObjectId(ctx.session.user.id);
+
+      const result = await ctx.db
+        .collection<WithoutId<BnplAccountDoc>>("bnpl_accounts")
+        .insertOne({ userId, name: input.name, dueDay: input.dueDay });
+
+      return {
+        _id: result.insertedId.toHexString(),
+        userId: userId.toHexString(),
+        name: input.name,
+        dueDay: input.dueDay,
+      };
+    }),
+
+  update: protectedProcedure
+    .input(UpdateBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
+
+      const updateFields: Partial<Pick<BnplAccountDoc, "name" | "dueDay">> = {};
+      if (input.data.name !== undefined) updateFields.name = input.data.name;
+      if (input.data.dueDay !== undefined)
+        updateFields.dueDay = input.data.dueDay;
+
+      if (Object.keys(updateFields).length === 0) return;
+
+      await ctx.db
+        .collection<BnplAccountDoc>("bnpl_accounts")
+        .updateOne({ _id: accountOid, userId: userOid }, { $set: updateFields });
+
+      if (input.data.dueDay === undefined) return;
+
+      // A new due day must be applied to the purchases already under this
+      // account, not just to future ones. Otherwise old purchases keep firing
+      // on the previous day while new ones fire on the new day, and the account
+      // silently splits into two statements a month — precisely what deriving
+      // `dtstart` from the account exists to prevent.
+      //
+      // Each purchase keeps its own first *month*; only the day-of-month moves.
+      const cursor = ctx.db
+        .collection<PurchaseDoc>("bills")
+        .find(
+          { userId: userOid, bnplAccountId: accountOid },
+          { projection: { "recurrence.dtstart": 1 } },
+        );
+      const purchases = await cursor.toArray();
+      await cursor.close();
+
+      const ops = purchases.flatMap((purchase) => {
+        const dtstart = purchase.recurrence?.dtstart;
+        if (!dtstart) return [];
+
+        return [
+          {
+            updateOne: {
+              filter: { _id: purchase._id, userId: userOid },
+              update: {
+                $set: {
+                  "recurrence.dtstart": deriveStatementDtstart(
+                    input.data.dueDay!,
+                    dtstart,
+                  ),
+                },
+              },
+            },
+          },
+        ];
+      });
+
+      if (ops.length > 0) {
+        await ctx.db.collection("bills").bulkWrite(ops);
+      }
+    }),
+
+  delete: protectedProcedure
+    .input(DeleteBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
+
+      // Cascade rather than unset: leaving the purchases behind as ordinary
+      // bills would make every installment materialize as its own row in the
+      // pay-period list.
+      const cursor = ctx.db
+        .collection<{ _id: ObjectId }>("bills")
+        .find(
+          { userId: userOid, bnplAccountId: accountOid },
+          { projection: { _id: 1 } },
+        );
+      const purchases = await cursor.toArray();
+      await cursor.close();
+
+      const billOids = purchases.map((p) => p._id);
+      if (billOids.length > 0) {
+        await ctx.db
+          .collection("bills")
+          .deleteMany({ _id: { $in: billOids }, userId: userOid });
+        await ctx.db
+          .collection("payments")
+          .deleteMany({ userId: userOid, billId: { $in: billOids } });
+      }
+
+      await ctx.db
+        .collection<BnplAccountDoc>("bnpl_accounts")
+        .deleteOne({ _id: accountOid, userId: userOid });
+    }),
+});
+```
+
+- [ ] **Step 3: Register the router**
+
+In `src/server/api/root.ts`, add the import and the entry:
+
+```ts
+import { bnplRouter } from "~/server/api/routers/bnpl";
+```
+
+```ts
+export const appRouter = createTRPCRouter({
+  post: postRouter,
+  bill: billRouter,
+  bnpl: bnplRouter,
+  group: groupRouter,
+  income: incomeRouter,
+  payment: paymentRouter,
+});
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/schemas/bnpl.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
+```
+
+Expected: both clean. The `input.data.dueDay!` non-null assertion inside the `flatMap` is guarded by the `undefined` early-return above it; if the lint config forbids `!`, hoist it instead: `const nextDueDay = input.data.dueDay;` before the early return, then use `nextDueDay`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schemas/bnpl.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
+git commit -m "feat: add BNPL account router with due-day schedule rewrite (#44)"
+```
+
+---
+
+## Task 5: Shared cascade helper and purchase mutations
+
+**Files:**
+- Create: `src/server/api/bill-cascade.ts`
+- Modify: `src/server/api/routers/bill.ts:120-146`
+- Modify: `src/server/api/routers/bnpl.ts`
+- Modify: `src/schemas/bnpl.ts`
+
+**Interfaces:**
+- Consumes: `assertAccountOwned`, `BnplAccountDoc` (Task 4), `deriveStatementDtstart` (Task 1).
+- Produces:
+  - `deleteBillsWithPayments(db, userOid, billOids): Promise<number>`.
+  - `bnpl.createPurchase({ accountId, title, amount, tenureMonths, firstDueMonth })` → `void`.
+  - `bnpl.updatePurchase({ id, data: { title, amount, tenureMonths, firstDueMonth } })` → `void`.
+  - `bnpl.deletePurchase({ id })` → `void`.
+
+- [ ] **Step 1: Extract the cascade helper**
+
+Create `src/server/api/bill-cascade.ts`:
+
+```ts
+import type { Db, ObjectId } from "mongodb";
+
+/**
+ * Delete bills together with the paid-occurrence markers pointing at them.
+ *
+ * Occurrences aren't stored rows — they're generated from a bill's recurrence —
+ * so a `payments` document is only meaningful while its bill exists. Deleting a
+ * bill without its payments leaves markers that can never be rendered or
+ * cleared.
+ *
+ * Shared by the bill router and the BNPL router: purchases are `bills` rows, but
+ * their mutations live in the BNPL router, so without this helper the same rule
+ * would be written twice and remembered once.
+ *
+ * Returns the number of bills actually deleted, so callers can distinguish "not
+ * found" from "deleted".
+ */
+export async function deleteBillsWithPayments(
+  db: Db,
+  userOid: ObjectId,
+  billOids: ObjectId[],
+): Promise<number> {
+  if (billOids.length === 0) return 0;
+
+  const result = await db
+    .collection("bills")
+    .deleteMany({ _id: { $in: billOids }, userId: userOid });
+
+  await db
+    .collection("payments")
+    .deleteMany({ userId: userOid, billId: { $in: billOids } });
+
+  return result.deletedCount;
+}
+```
+
+- [ ] **Step 2: Use it in the bill router**
+
+In `src/server/api/routers/bill.ts`, add the import:
+
+```ts
+import { deleteBillsWithPayments } from "../bill-cascade";
+```
+
+Replace the body of the `delete` procedure (currently the `deleteOne` plus the trailing `payments` `deleteMany`) with:
+
+```ts
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      if (!ObjectId.isValid(input.id)) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
+      }
+
+      const deleted = await deleteBillsWithPayments(
+        ctx.db,
+        new ObjectId(ctx.session.user.id),
+        [new ObjectId(input.id)],
+      );
+
+      if (deleted === 0) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
+      }
+    }),
+```
+
+- [ ] **Step 3: Use it in the account delete**
+
+In `src/server/api/routers/bnpl.ts`, add the import and replace the two `deleteMany` calls written in Task 4 with the helper:
+
+```ts
+import { deleteBillsWithPayments } from "../bill-cascade";
+```
+
+```ts
+      const billOids = purchases.map((p) => p._id);
+      await deleteBillsWithPayments(ctx.db, userOid, billOids);
+```
+
+- [ ] **Step 4: Add the purchase schemas**
+
+Append to `src/schemas/bnpl.ts`:
+
+```ts
+// A purchase's schedule is not accepted from the client: only its first *month*
+// is, and the day comes from the account. That's what makes one consolidated
+// statement per month impossible to violate rather than merely discouraged.
+const purchaseFieldsSchema = z.object({
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  // Required, unlike the shared bill schema's optional amount — an installment
+  // with no amount can't contribute to a statement total.
+  amount: z.number().min(1, { message: "Amount is required" }),
+  tenureMonths: z.number().int().min(1).max(60),
+  firstDueMonth: z.date(),
+});
+
+export const CreateBnplPurchaseInputSchema = purchaseFieldsSchema.extend({
+  accountId: z.string(),
+});
+
+export const UpdateBnplPurchaseInputSchema = z.object({
+  id: z.string(),
+  data: purchaseFieldsSchema,
+});
+
+export const DeleteBnplPurchaseInputSchema = z.object({ id: z.string() });
+
+export type CreateBnplPurchaseInput = z.infer<
+  typeof CreateBnplPurchaseInputSchema
+>;
+export type UpdateBnplPurchaseInput = z.infer<
+  typeof UpdateBnplPurchaseInputSchema
+>;
+```
+
+- [ ] **Step 5: Add the purchase mutations**
+
+In `src/server/api/routers/bnpl.ts`, extend the imports:
+
+```ts
+import {
+  CreateBnplAccountInputSchema,
+  CreateBnplPurchaseInputSchema,
+  DeleteBnplAccountInputSchema,
+  DeleteBnplPurchaseInputSchema,
+  UpdateBnplAccountInputSchema,
+  UpdateBnplPurchaseInputSchema,
+} from "~/schemas/bnpl";
+```
+
+Add these procedures inside `bnplRouter`:
+
+```ts
+  createPurchase: protectedProcedure
+    .input(CreateBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid, dueDay } = await assertAccountOwned(
+        ctx,
+        input.accountId,
+      );
+
+      await ctx.db.collection("bills").insertOne({
+        userId: userOid,
+        bnplAccountId: accountOid,
+        title: input.title,
+        amount: input.amount,
+        type: "recurring",
+        recurrence: {
+          type: "monthly",
+          interval: 1,
+          // Derived, never client-supplied: the account owns the day.
+          dtstart: deriveStatementDtstart(dueDay, input.firstDueMonth),
+          count: input.tenureMonths,
+        },
+      });
+    }),
+
+  updatePurchase: protectedProcedure
+    .input(UpdateBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ObjectId.isValid(input.id)) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+      }
+
+      const userOid = new ObjectId(ctx.session.user.id);
+      const purchase = await ctx.db
+        .collection<{ _id: ObjectId; bnplAccountId?: ObjectId }>("bills")
+        .findOne(
+          { _id: new ObjectId(input.id), userId: userOid },
+          { projection: { bnplAccountId: 1 } },
+        );
+
+      // Guard on bnplAccountId, not just existence: this endpoint must not be
+      // usable to reshape an ordinary bill into an installment.
+      if (!purchase?.bnplAccountId) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+      }
+
+      const { dueDay } = await assertAccountOwned(
+        ctx,
+        purchase.bnplAccountId.toHexString(),
+      );
+
+      await ctx.db.collection("bills").updateOne(
+        { _id: purchase._id, userId: userOid },
+        {
+          $set: {
+            title: input.data.title,
+            amount: input.data.amount,
+            type: "recurring",
+            recurrence: {
+              type: "monthly",
+              interval: 1,
+              dtstart: deriveStatementDtstart(dueDay, input.data.firstDueMonth),
+              count: input.data.tenureMonths,
+            },
+          },
+        },
+      );
+    }),
+
+  deletePurchase: protectedProcedure
+    .input(DeleteBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ObjectId.isValid(input.id)) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+      }
+
+      const deleted = await deleteBillsWithPayments(
+        ctx.db,
+        new ObjectId(ctx.session.user.id),
+        [new ObjectId(input.id)],
+      );
+
+      if (deleted === 0) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+      }
+    }),
+```
+
+- [ ] **Step 6: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/server/api/bill-cascade.ts src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
+```
+
+- [ ] **Step 7: Run the existing tests**
+
+Run: `pnpm test`
+Expected: PASS — nothing in Tasks 1–3 should be affected.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/server/api/bill-cascade.ts src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
+git commit -m "feat: add BNPL purchase mutations and shared bill cascade (#44)"
+```
+
+---
+
+## Task 6: Statement-level paid mutations
+
+**Files:**
+- Modify: `src/server/api/routers/payment.ts`
+
+**Interfaces:**
+- Consumes: `assertAccountOwned` (Task 4), `truncateToUtcDateOnly`.
+- Produces:
+  - `payment.markStatementPaid({ accountId, statementDate, billIds })` → `void`.
+  - `payment.markStatementUnpaid({ accountId, statementDate, billIds })` → `void`.
+
+- [ ] **Step 1: Add the mutations**
+
+In `src/server/api/routers/payment.ts`, extend the imports:
+
+```ts
+import { assertAccountOwned } from "./bnpl";
+```
+
+Add a shared validation helper above `paymentRouter`:
+
+```ts
+// A statement is settled as a unit, so its mutations act on a set of bill ids.
+// Every id must belong to the requesting user *and* to the named account —
+// otherwise this endpoint would be a way to write payments against arbitrary
+// bills in bulk.
+async function assertPurchasesInAccount(
+  ctx: { db: Db; session: { user: { id: string } } },
+  accountId: string,
+  billIds: string[],
+): Promise<{ billOids: ObjectId[]; userOid: ObjectId }> {
+  const { accountOid, userOid } = await assertAccountOwned(ctx, accountId);
+
+  if (billIds.some((id) => !ObjectId.isValid(id))) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+  }
+
+  const billOids = billIds.map((id) => new ObjectId(id));
+  const matched = await ctx.db.collection("bills").countDocuments({
+    _id: { $in: billOids },
+    userId: userOid,
+    bnplAccountId: accountOid,
+  });
+
+  if (matched !== billOids.length) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+  }
+
+  return { billOids, userOid };
+}
+```
+
+Add the input schema and both procedures inside `paymentRouter`:
+
+```ts
+  markStatementPaid: protectedProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        statementDate: z.date(),
+        billIds: z.array(z.string()).min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { billOids, userOid } = await assertPurchasesInAccount(
+        ctx,
+        input.accountId,
+        input.billIds,
+      );
+      const occurrenceDate = truncateToUtcDateOnly(input.statementDate);
+
+      // One bulkWrite rather than N client mutations: a statement is a single
+      // user action and shouldn't be able to land half-applied because a
+      // request in the middle failed.
+      await ctx.db.collection("payments").bulkWrite(
+        billOids.map((billId) => ({
+          updateOne: {
+            filter: { userId: userOid, billId, occurrenceDate },
+            update: { $set: { paidAt: new Date() } },
+            upsert: true,
+          },
+        })),
+      );
+    }),
+
+  markStatementUnpaid: protectedProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        statementDate: z.date(),
+        billIds: z.array(z.string()).min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { billOids, userOid } = await assertPurchasesInAccount(
+        ctx,
+        input.accountId,
+        input.billIds,
+      );
+
+      // deleteMany, mirroring markUnpaid: self-heals any duplicate a concurrent
+      // upsert race may have created.
+      await ctx.db.collection("payments").deleteMany({
+        userId: userOid,
+        billId: { $in: billOids },
+        occurrenceDate: truncateToUtcDateOnly(input.statementDate),
+      });
+    }),
+```
+
+- [ ] **Step 2: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/server/api/routers/payment.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/api/routers/payment.ts
+git commit -m "feat: add statement-level paid mutations (#44)"
+```
+
+---
+
+## Task 7: `/bnpl` page, account list, and nav
+
+**Files:**
+- Create: `src/app/bnpl/page.tsx`
+- Create: `src/components/bnplManager.tsx`
+- Create: `src/components/bnplAccountFormDialog.tsx`
+- Modify: `src/components/authenticatedLayout.tsx:5-13,100-104`
+
+**Interfaces:**
+- Consumes: `bnpl.getAll`, `bnpl.create`, `bnpl.update`, `bnpl.delete` (Task 4); `BnplAccount` (Task 3).
+- Produces: `<BnplManager />`; `<BnplAccountFormDialog open onOpenChange account? />` where `account?: BnplAccount` switches it between create and edit.
+
+- [ ] **Step 1: Add the nav link**
+
+In `src/components/authenticatedLayout.tsx`, add `CreditCard` to the `lucide-react` import list (keep it alphabetical: after `Receipt` is wrong — it goes first, before `FlaskConical`):
+
+```ts
+import {
+  CreditCard,
+  FlaskConical,
+  FolderTree,
+  LayoutDashboard,
+  Menu,
+  Receipt,
+  type LucideIcon,
+} from "lucide-react";
+```
+
+Then extend `navLinks`:
+
+```ts
+const navLinks: Array<{ href: string; label: string; icon: LucideIcon }> = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/groups", label: "Groups", icon: FolderTree },
+  { href: "/bnpl", label: "BNPL", icon: CreditCard },
+  { href: "/playground", label: "Playground", icon: FlaskConical },
+];
+```
+
+- [ ] **Step 2: Create the account form dialog**
+
+Create `src/components/bnplAccountFormDialog.tsx`:
+
+```tsx
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import type { BnplAccount } from "~/types";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./ui/form";
+import { Input } from "./ui/input";
+
+const AccountFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "Name is required" }).max(50),
+  dueDay: z.coerce.number().int().min(1).max(31),
+});
+
+type AccountFormValues = z.infer<typeof AccountFormSchema>;
+
+export function BnplAccountFormDialog({
+  open,
+  onOpenChange,
+  account,
+  onSubmit,
+  isPending,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  account?: BnplAccount;
+  onSubmit: (values: AccountFormValues) => void;
+  isPending: boolean;
+}) {
+  const form = useForm<AccountFormValues>({
+    resolver: zodResolver(AccountFormSchema),
+    defaultValues: { name: "", dueDay: 15 },
+  });
+
+  // Reset on open so an edit shows the current values and a create starts clean.
+  useEffect(() => {
+    if (!open) return;
+    form.reset(
+      account
+        ? { name: account.name, dueDay: account.dueDay }
+        : { name: "", dueDay: 15 },
+    );
+  }, [open, account, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{account ? "Edit account" : "New account"}</DialogTitle>
+          <DialogDescription>
+            A BNPL provider bills every purchase on one monthly statement.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+            id="bnpl-account-form"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="SPayLater" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="dueDay"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Statement due day</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} max={31} {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Months without this day use their last day instead.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="bnpl-account-form" disabled={isPending}>
+            {isPending && <Loader2 className="mr-1 size-4 animate-spin" />}
+            {account ? "Save" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 3: Create the manager**
+
+Create `src/components/bnplManager.tsx`. The account card itself arrives in Task 8; this task renders a placeholder row per account so the CRUD is verifiable on its own.
+
+```tsx
+"use client";
+
+import { CreditCard, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { api } from "~/trpc/react";
+import type { BnplAccount } from "~/types";
+import { AuthenticatedLayout } from "./authenticatedLayout";
+import { BnplAccountFormDialog } from "./bnplAccountFormDialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
+import { Skeleton } from "./ui/skeleton";
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="border-ledger-line flex flex-col items-center rounded-lg border border-dashed py-12">
+      <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-3 flex size-11 items-center justify-center rounded-2xl">
+        <CreditCard className="size-5" />
+      </span>
+      <h3 className="text-ledger-ink font-display text-lg">No BNPL accounts</h3>
+      <p className="text-ledger-muted mt-1 text-sm">
+        Add an account to track its installments separately from your bills.
+      </p>
+      <Button className="mt-4" onClick={onAdd}>
+        New Account <Plus className="ml-1 size-4" />
+      </Button>
+    </div>
+  );
+}
+
+export function BnplManager() {
+  const utils = api.useUtils();
+  const { data: accounts, isLoading } = api.bnpl.getAll.useQuery();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<BnplAccount | null>(null);
+  const [deleting, setDeleting] = useState<BnplAccount | null>(null);
+
+  const invalidate = () =>
+    Promise.all([
+      utils.bnpl.getAll.invalidate(),
+      utils.bill.getAll.invalidate(),
+      utils.payment.getAll.invalidate(),
+    ]);
+
+  const createMut = api.bnpl.create.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account created");
+      setCreateOpen(false);
+    },
+    onError: (e) => toast.error(e.message || "Failed to create account"),
+  });
+
+  const updateMut = api.bnpl.update.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account updated");
+      setEditing(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to update account"),
+  });
+
+  const deleteMut = api.bnpl.delete.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account deleted");
+      setDeleting(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to delete account"),
+  });
+
+  return (
+    <AuthenticatedLayout>
+      <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-ledger-ink font-display text-xl">BNPL</h1>
+          {accounts && accounts.length > 0 && (
+            <Button size="sm" onClick={() => setCreateOpen(true)}>
+              New Account <Plus className="ml-1 size-4" />
+            </Button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-3xl" />
+            ))}
+          </div>
+        ) : !accounts || accounts.length === 0 ? (
+          <EmptyState onAdd={() => setCreateOpen(true)} />
+        ) : (
+          <div className="space-y-4">
+            {accounts.map((account) => (
+              <div
+                key={account._id}
+                className="border-border/40 bg-card flex items-center justify-between rounded-3xl border p-5"
+              >
+                <div>
+                  <p className="text-foreground font-semibold">
+                    {account.name}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Due day {account.dueDay}
+                  </p>
+                </div>
+                <div className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Edit account"
+                    onClick={() => setEditing(account)}
+                  >
+                    <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Delete account"
+                    onClick={() => setDeleting(account)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <BnplAccountFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSubmit={(values) => createMut.mutate(values)}
+        isPending={createMut.isPending}
+      />
+
+      <BnplAccountFormDialog
+        open={editing !== null}
+        onOpenChange={(open) => !open && setEditing(null)}
+        account={editing ?? undefined}
+        onSubmit={(values) => {
+          if (!editing) return;
+          updateMut.mutate({ id: editing._id, data: values });
+        }}
+        isPending={updateMut.isPending}
+      />
+
+      <AlertDialog
+        open={deleting !== null}
+        onOpenChange={(open) => !open && setDeleting(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {deleting?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This also deletes every purchase under this account and its
+              payment history. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (deleting) deleteMut.mutate({ id: deleting._id });
+              }}
+              disabled={deleteMut.isPending}
+            >
+              {deleteMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AuthenticatedLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Create the page**
+
+Create `src/app/bnpl/page.tsx`, mirroring `src/app/groups/page.tsx`:
+
+```tsx
+import { BnplManager } from "~/components/bnplManager";
+
+export const dynamic = "force-dynamic";
+
+export default function BnplPage() {
+  return <BnplManager />;
+}
+```
+
+- [ ] **Step 5: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/app/bnpl/page.tsx src/components/bnplManager.tsx src/components/bnplAccountFormDialog.tsx src/components/authenticatedLayout.tsx
+```
+
+- [ ] **Step 6: Verify in the running app**
+
+Run `pnpm dev`, sign in, and confirm:
+1. **BNPL** appears in the nav and `/bnpl` loads.
+2. With no accounts, the empty state shows and its button opens the dialog.
+3. Creating an account named `SPayLater` with due day `15` lists it as "Due day 15".
+4. Editing the name and due day persists after a reload.
+5. Deleting it asks for confirmation and removes it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/bnpl src/components/bnplManager.tsx src/components/bnplAccountFormDialog.tsx src/components/authenticatedLayout.tsx
+git commit -m "feat: add /bnpl page with account CRUD (#44)"
+```
+
+---
+
+## Task 8: Account card — purchases, statement, paid toggle
+
+**Files:**
+- Create: `src/components/bnplAccountCard.tsx`
+- Create: `src/components/bnplPurchaseFormDialog.tsx`
+- Modify: `src/components/bnplManager.tsx`
+
+**Interfaces:**
+- Consumes: `partitionBills` (Task 2), `groupStatements` + `installmentProgress` (Task 3), `bnpl.createPurchase` / `updatePurchase` / `deletePurchase` (Task 5), `payment.markStatementPaid` / `markStatementUnpaid` (Task 6), `computeBillsInPeriod` from `~/lib/bill-utils`.
+- Produces: `<BnplAccountCard account purchases statements paidKeys ... />`, replacing the placeholder row in `BnplManager`.
+
+- [ ] **Step 1: Create the purchase form dialog**
+
+Create `src/components/bnplPurchaseFormDialog.tsx`. The month field uses a native `<input type="month">`, whose value is `"yyyy-MM"`; parsing it as `new Date("2026-09")` yields UTC midnight on the 1st, which is exactly the canonical frame the server expects.
+
+```tsx
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { formatUtcDate } from "~/lib/date-utils";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./ui/form";
+import { Input } from "./ui/input";
+
+const PurchaseFormSchema = z.object({
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  amount: z.coerce.number().min(1, { message: "Amount is required" }),
+  tenureMonths: z.coerce.number().int().min(1).max(60),
+  firstDueMonth: z.date(),
+});
+
+export type PurchaseFormValues = z.infer<typeof PurchaseFormSchema>;
+
+/** `"yyyy-MM"` → UTC midnight on the 1st, or undefined when cleared/invalid. */
+function monthInputToUtc(value: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(`${value}-01`);
+  return isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export function BnplPurchaseFormDialog({
+  open,
+  onOpenChange,
+  accountName,
+  initialValues,
+  onSubmit,
+  isPending,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountName: string;
+  initialValues?: PurchaseFormValues;
+  onSubmit: (values: PurchaseFormValues) => void;
+  isPending: boolean;
+}) {
+  const form = useForm<PurchaseFormValues>({
+    resolver: zodResolver(PurchaseFormSchema),
+    defaultValues: {
+      title: "",
+      amount: 0,
+      tenureMonths: 6,
+      firstDueMonth: new Date(
+        Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
+      ),
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (initialValues) form.reset(initialValues);
+  }, [open, initialValues, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {initialValues ? "Edit purchase" : "New purchase"}
+          </DialogTitle>
+          <DialogDescription>
+            Billed on {accountName}&apos;s monthly statement.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+            id="bnpl-purchase-form"
+          >
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Item</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Airpods" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Monthly installment</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} step="0.01" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tenureMonths"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Months</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} max={60} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="firstDueMonth"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First statement month</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="month"
+                      value={
+                        field.value ? formatUtcDate(field.value, "yyyy-MM") : ""
+                      }
+                      onChange={(e) =>
+                        field.onChange(monthInputToUtc(e.target.value))
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The day comes from the account&apos;s due day.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="bnpl-purchase-form" disabled={isPending}>
+            {isPending && <Loader2 className="mr-1 size-4 animate-spin" />}
+            {initialValues ? "Save" : "Add"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Create the account card**
+
+Create `src/components/bnplAccountCard.tsx`:
+
+```tsx
+"use client";
+
+import {
+  Circle,
+  CircleCheckBig,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { installmentProgress, type Statement } from "~/lib/bnpl-utils";
+import { formatUtcDate } from "~/lib/date-utils";
+import { cn } from "~/lib/utils";
+import type { BillEvent, BnplAccount } from "~/types";
+import { Button } from "./ui/button";
+
+function formatPHP(value: number) {
+  return value.toLocaleString("en-PH", {
+    style: "currency",
+    currency: "PHP",
+  });
+}
+
+export function BnplAccountCard({
+  account,
+  purchases,
+  statement,
+  isStatementPaid,
+  isStatementPending,
+  onToggleStatementPaid,
+  onEditAccount,
+  onDeleteAccount,
+  onAddPurchase,
+  onEditPurchase,
+  onDeletePurchase,
+}: {
+  account: BnplAccount;
+  purchases: BillEvent[];
+  statement: Statement | null;
+  isStatementPaid: boolean;
+  isStatementPending: boolean;
+  onToggleStatementPaid: () => void;
+  onEditAccount: () => void;
+  onDeleteAccount: () => void;
+  onAddPurchase: () => void;
+  onEditPurchase: (purchase: BillEvent) => void;
+  onDeletePurchase: (purchase: BillEvent) => void;
+}) {
+  return (
+    <div className="border-border/40 bg-card flex flex-col overflow-hidden rounded-3xl border">
+      <div className="flex items-start justify-between px-5 pt-5 pb-3">
+        <div>
+          <p className="text-foreground font-semibold">{account.name}</p>
+          <p className="text-muted-foreground font-mono text-xs tabular-nums">
+            Due day {account.dueDay}
+          </p>
+          {statement ? (
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                className={cn(
+                  "shrink-0 transition-colors disabled:opacity-50",
+                  isStatementPaid
+                    ? "text-ledger-accent-strong dark:text-ledger-accent"
+                    : "text-muted-foreground/50 hover:text-muted-foreground",
+                )}
+                onClick={onToggleStatementPaid}
+                disabled={isStatementPending}
+                aria-label={
+                  isStatementPaid ? "Mark statement unpaid" : "Mark statement paid"
+                }
+                aria-pressed={isStatementPaid}
+              >
+                {isStatementPaid ? (
+                  <CircleCheckBig className="size-4" />
+                ) : (
+                  <Circle className="size-4" />
+                )}
+              </button>
+              <span
+                className={cn(
+                  "font-mono text-2xl font-semibold tracking-tight tabular-nums",
+                  isStatementPaid && "line-through opacity-50",
+                )}
+              >
+                {formatPHP(statement.amount)}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                due {formatUtcDate(statement.date, "MMM d")}
+              </span>
+            </div>
+          ) : (
+            <p className="text-muted-foreground mt-3 text-sm">
+              Nothing due — no active purchases.
+            </p>
+          )}
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Edit account"
+            onClick={onEditAccount}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete account"
+            onClick={onDeleteAccount}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="px-5 pb-5">
+        <ul className="divide-border/40 divide-y">
+          {purchases.map((purchase) => {
+            if (purchase.type !== "recurring") return null;
+            const { elapsed, total } = installmentProgress(
+              purchase.recurrence.dtstart,
+              purchase.recurrence.count,
+              statement?.date ?? new Date(),
+            );
+            const isDone = elapsed >= total;
+
+            return (
+              <li
+                key={purchase._id}
+                className={cn(
+                  "flex items-center gap-3 py-2",
+                  isDone && "opacity-50",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {purchase.title}
+                  </div>
+                  <div className="text-muted-foreground font-mono text-[11px] tabular-nums">
+                    {isDone ? "Done" : `${elapsed} of ${total}`}
+                  </div>
+                </div>
+                <span className="w-24 shrink-0 text-right font-mono text-sm font-semibold tabular-nums">
+                  {formatPHP(purchase.amount ?? 0)}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Edit purchase"
+                  onClick={() => onEditPurchase(purchase)}
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Delete purchase"
+                  onClick={() => onDeletePurchase(purchase)}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={onAddPurchase}
+        >
+          Add purchase <Plus className="ml-1 size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the card into the manager**
+
+In `src/components/bnplManager.tsx`, replace the placeholder account row with `<BnplAccountCard />` and add the derived data. Add these imports:
+
+```tsx
+import { addMonths } from "date-fns";
+import { useMemo, useState } from "react";
+import { computeBillsInPeriod, partitionBills } from "~/lib/bill-utils";
+import { groupStatements } from "~/lib/bnpl-utils";
+import { localDateToUtcDateOnly } from "~/lib/date-utils";
+import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
+import type { BillEvent } from "~/types";
+import { BnplAccountCard } from "./bnplAccountCard";
+import {
+  BnplPurchaseFormDialog,
+  type PurchaseFormValues,
+} from "./bnplPurchaseFormDialog";
+```
+
+Add the queries and derivations inside `BnplManager`, after the existing `accounts` query:
+
+```tsx
+  const { data: bills } = api.bill.getAll.useQuery();
+  const { data: payments } = api.payment.getAll.useQuery();
+
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+
+  // Statements are read off the same occurrence generator the dashboard uses,
+  // rather than re-deriving dates here — one scheduler, one set of clamping
+  // rules. A 14-month window is enough to always contain the next statement.
+  const { purchasesByAccount, statementByAccount } = useMemo(() => {
+    const { installments } = partitionBills(bills ?? []);
+    // Already UTC midnight — localDateToUtcDateOnly maps today's local
+    // calendar day onto the canonical frame the scheduler anchors on.
+    const windowStart = localDateToUtcDateOnly(new Date());
+    const occurrences = computeBillsInPeriod(
+      installments,
+      windowStart,
+      addMonths(windowStart, 14),
+    );
+    const statements = groupStatements(occurrences, accounts ?? []);
+
+    const purchasesByAccount = new Map<string, BillEvent[]>();
+    for (const purchase of installments) {
+      if (!purchase.bnplAccountId) continue;
+      const list = purchasesByAccount.get(purchase.bnplAccountId) ?? [];
+      list.push(purchase);
+      purchasesByAccount.set(purchase.bnplAccountId, list);
+    }
+
+    // The first statement per account is the current one, since groupStatements
+    // sorts by date and the window starts today.
+    const statementByAccount = new Map<string, (typeof statements)[number]>();
+    for (const statement of statements) {
+      if (!statementByAccount.has(statement.accountId)) {
+        statementByAccount.set(statement.accountId, statement);
+      }
+    }
+
+    return { purchasesByAccount, statementByAccount };
+  }, [bills, accounts]);
+```
+
+Add the purchase and statement mutations alongside the existing account mutations:
+
+```tsx
+  const [purchaseTarget, setPurchaseTarget] = useState<{
+    account: BnplAccount;
+    purchase?: BillEvent;
+  } | null>(null);
+  const [deletingPurchase, setDeletingPurchase] = useState<BillEvent | null>(
+    null,
+  );
+  const [pendingStatements, setPendingStatements] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const createPurchaseMut = api.bnpl.createPurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase added");
+      setPurchaseTarget(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to add purchase"),
+  });
+
+  const updatePurchaseMut = api.bnpl.updatePurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase updated");
+      setPurchaseTarget(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to update purchase"),
+  });
+
+  const deletePurchaseMut = api.bnpl.deletePurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase deleted");
+      setDeletingPurchase(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to delete purchase"),
+  });
+
+  const markStatementPaid = api.payment.markStatementPaid.useMutation();
+  const markStatementUnpaid = api.payment.markStatementUnpaid.useMutation();
+
+  // A statement is paid only when every purchase on it is paid, so a purchase
+  // added after settling correctly flips it back to unpaid.
+  const isStatementPaid = (statement: Statement) =>
+    statement.billIds.every((billId) =>
+      paidKeys.has(occurrenceKey(billId, statement.date)),
+    );
+
+  const handleToggleStatement = (statement: Statement) => {
+    const key = `${statement.accountId}:${statement.date.getTime()}`;
+    const currentlyPaid = isStatementPaid(statement);
+    setPendingStatements((prev) => new Set(prev).add(key));
+    const clearPending = () =>
+      setPendingStatements((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+
+    const mutation = currentlyPaid ? markStatementUnpaid : markStatementPaid;
+    mutation.mutate(
+      {
+        accountId: statement.accountId,
+        statementDate: statement.date,
+        billIds: statement.billIds,
+      },
+      {
+        onSuccess: () =>
+          void utils.payment.getAll.invalidate().finally(clearPending),
+        onError: (error) => {
+          toast.error(error.message || "Failed to update statement");
+          clearPending();
+        },
+      },
+    );
+  };
+```
+
+Import `Statement` as a type alongside `groupStatements`:
+
+```tsx
+import { groupStatements, type Statement } from "~/lib/bnpl-utils";
+```
+
+Replace the placeholder `<div key={account._id} …>` block with:
+
+```tsx
+            {accounts.map((account) => {
+              const statement = statementByAccount.get(account._id) ?? null;
+              const statementKey = statement
+                ? `${statement.accountId}:${statement.date.getTime()}`
+                : "";
+
+              return (
+                <BnplAccountCard
+                  key={account._id}
+                  account={account}
+                  purchases={purchasesByAccount.get(account._id) ?? []}
+                  statement={statement}
+                  isStatementPaid={statement ? isStatementPaid(statement) : false}
+                  isStatementPending={pendingStatements.has(statementKey)}
+                  onToggleStatementPaid={() =>
+                    statement && handleToggleStatement(statement)
+                  }
+                  onEditAccount={() => setEditing(account)}
+                  onDeleteAccount={() => setDeleting(account)}
+                  onAddPurchase={() => setPurchaseTarget({ account })}
+                  onEditPurchase={(purchase) =>
+                    setPurchaseTarget({ account, purchase })
+                  }
+                  onDeletePurchase={setDeletingPurchase}
+                />
+              );
+            })}
+```
+
+Add the purchase dialog and its delete confirmation next to the account dialogs:
+
+```tsx
+      <BnplPurchaseFormDialog
+        open={purchaseTarget !== null}
+        onOpenChange={(open) => !open && setPurchaseTarget(null)}
+        accountName={purchaseTarget?.account.name ?? ""}
+        initialValues={
+          purchaseTarget?.purchase &&
+          purchaseTarget.purchase.type === "recurring"
+            ? {
+                title: purchaseTarget.purchase.title,
+                amount: purchaseTarget.purchase.amount ?? 0,
+                tenureMonths: purchaseTarget.purchase.recurrence.count ?? 1,
+                firstDueMonth: purchaseTarget.purchase.recurrence.dtstart,
+              }
+            : undefined
+        }
+        onSubmit={(values: PurchaseFormValues) => {
+          if (!purchaseTarget) return;
+          if (purchaseTarget.purchase) {
+            updatePurchaseMut.mutate({
+              id: purchaseTarget.purchase._id,
+              data: values,
+            });
+          } else {
+            createPurchaseMut.mutate({
+              accountId: purchaseTarget.account._id,
+              ...values,
+            });
+          }
+        }}
+        isPending={createPurchaseMut.isPending || updatePurchaseMut.isPending}
+      />
+
+      <AlertDialog
+        open={deletingPurchase !== null}
+        onOpenChange={(open) => !open && setDeletingPurchase(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {deletingPurchase?.title}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the purchase and its payment history. This cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletePurchaseMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (deletingPurchase)
+                  deletePurchaseMut.mutate({ id: deletingPurchase._id });
+              }}
+              disabled={deletePurchaseMut.isPending}
+            >
+              {deletePurchaseMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/components/bnplAccountCard.tsx src/components/bnplPurchaseFormDialog.tsx src/components/bnplManager.tsx
+```
+
+- [ ] **Step 5: Verify in the running app**
+
+With `pnpm dev`, on `/bnpl`:
+1. Add a purchase: `Airpods`, `1250`, `6` months, this month. The card's statement shows `₱1,250` due on the account's due day.
+2. Add a second purchase `Fan`, `700`, `3` months, same month. The statement becomes `₱1,950` — one line, not two.
+3. Mark the statement paid: the amount strikes through, both purchases count as paid.
+4. Add a third purchase in the same month — the statement flips back to unpaid (expected).
+5. Edit the **account's** due day from 15 to 20 and reload: the statement date moves to the 20th and stays a *single* statement.
+6. Set the due day to 31 and add a purchase whose first month is February: the statement lands on Feb 28.
+7. Delete a purchase, then delete the account, confirming both dialogs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/bnplAccountCard.tsx src/components/bnplPurchaseFormDialog.tsx src/components/bnplManager.tsx
+git commit -m "feat: manage BNPL purchases and settle statements on /bnpl (#44)"
+```
+
+---
+
+## Task 9: Roll-up rows in the pay-period bill list
+
+**Files:**
+- Modify: `src/app/_components/billList.tsx`
+
+**Interfaces:**
+- Consumes: `partitionBills` (Task 2), `groupStatements` + `Statement` (Task 3), `bnpl.getAll` (Task 4).
+- Produces: no new exports.
+
+- [ ] **Step 1: Add the account query and imports**
+
+In `src/app/_components/billList.tsx`, add to the imports:
+
+```tsx
+import { getPayPeriodsByCount, partitionBills } from "~/lib/bill-utils";
+import { groupStatements } from "~/lib/bnpl-utils";
+import type { BillEvent, BnplAccount, Group } from "~/types";
+```
+
+In `BillList`, add the query and pass accounts down:
+
+```tsx
+  const { data: accounts } = api.bnpl.getAll.useQuery();
+```
+
+Extend the loading guard so accounts are present before rendering:
+
+```tsx
+  if (!incomeProfile || !bills || !groups || !accounts) return null;
+```
+
+Pass `accounts={accounts}` to each `<BillListCard />`.
+
+- [ ] **Step 2: Render the roll-up rows**
+
+In `BillListCard`, accept `accounts: BnplAccount[]` in its props, then split the rows and compute statements:
+
+```tsx
+  const { bills: ordinaryBills, installments } = useMemo(
+    () => partitionBills(bills),
+    [bills],
+  );
+
+  const sections = useMemo(
+    () => buildSections(ordinaryBills, groups),
+    [ordinaryBills, groups],
+  );
+
+  const statements = useMemo(
+    () => groupStatements(installments, accounts),
+    [installments, accounts],
+  );
+```
+
+`outgoing` must keep summing **all** rows — installments included — so the balance stays an honest projection:
+
+```tsx
+  // Installments are counted here but itemized as one roll-up row per account
+  // below, so section subtotals plus statement amounts still equal `outgoing`.
+  const outgoing = useMemo(
+    () =>
+      sumBy(
+        bills.filter((bill) => !excludedBills.includes(bill._id)),
+        (bill) => bill.amount ?? 0,
+      ),
+    [bills, excludedBills],
+  );
+```
+
+Replace the `bills.length === 0` empty-state condition with one that accounts for statements:
+
+```tsx
+        {ordinaryBills.length === 0 && statements.length === 0 ? (
+```
+
+Then render the statement rows after the `sections.map(...)` block, inside the same `space-y-5` container:
+
+```tsx
+            {statements.map((statement, idx) => (
+              <div
+                key={`${statement.accountId}:${statement.date.getTime()}`}
+                className={cn(
+                  (sections.length > 0 || idx > 0) &&
+                    "border-border/40 border-t pt-5",
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <CreditCard className="text-muted-foreground size-3.5 shrink-0" />
+                    <span className="text-foreground text-sm font-semibold">
+                      {statement.accountName}
+                    </span>
+                    <span className="bg-muted/60 text-muted-foreground ml-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
+                      {statement.purchaseCount}
+                    </span>
+                    <span className="text-muted-foreground ml-1 font-mono text-[11px] tabular-nums">
+                      {formatUtcDate(statement.date, "MMM d")}
+                    </span>
+                  </div>
+                  <span className="w-24 text-right font-mono text-sm font-medium tracking-tight tabular-nums">
+                    {formatPHP(statement.amount)}
+                  </span>
+                </div>
+              </div>
+            ))}
+```
+
+Add `CreditCard` to the `lucide-react` import.
+
+- [ ] **Step 3: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/app/_components/billList.tsx
+```
+
+- [ ] **Step 4: Verify in the running app**
+
+On `/dashboard`, with at least one ordinary bill and two BNPL purchases on the same account:
+1. The purchases do **not** appear as individual rows.
+2. One roll-up row shows the account name, purchase count, statement date, and summed amount.
+3. Section subtotals plus the roll-up amount equal the card's "going out" figure.
+4. A second account with a purchase in the same period produces a second roll-up row.
+5. A period with only a statement and no ordinary bills shows the roll-up, not "Nothing due this period".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/_components/billList.tsx
+git commit -m "feat: show BNPL statements as roll-up rows in the bill list (#44)"
+```
+
+---
+
+## Task 10: Summary cards and playground cloning
+
+**Files:**
+- Modify: `src/components/financialSummaryCards.tsx`
+- Modify: `src/components/playgroundStartScreen.tsx:31`
+
+**Interfaces:**
+- Consumes: `partitionBills` (Task 2), `groupStatements` (Task 3), `bnpl.getAll` (Task 4).
+- Produces: no new exports.
+
+- [ ] **Step 1: Partition in the summary cards**
+
+In `src/components/financialSummaryCards.tsx`, add to the imports:
+
+```tsx
+import {
+  computeBillsInPeriod,
+  createPayRule,
+  partitionBills,
+} from "~/lib/bill-utils";
+import { groupStatements } from "~/lib/bnpl-utils";
+```
+
+Add the accounts query beside the payments query:
+
+```tsx
+  const { data: accounts } = api.bnpl.getAll.useQuery();
+```
+
+Rework the `useMemo` so "Total Bills" and "Next Bill" treat a statement as one item while "Remaining" keeps counting the money. Replace the existing `remaining`/`nextBill` computation with:
+
+```tsx
+  const { remaining, nextItem, billCount } = useMemo(() => {
+    const payRule = createPayRule(incomeProfile);
+    const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
+    if (!currentPay) return { remaining: 0, nextItem: null, billCount: 0 };
+
+    const nextPayDate = payRule.after(currentPay);
+    if (!nextPayDate) return { remaining: 0, nextItem: null, billCount: 0 };
+
+    const periodRows = computeBillsInPeriod(bills, currentPay, nextPayDate);
+    const { bills: ordinaryRows, installments } = partitionBills(periodRows);
+    const statements = groupStatements(installments, accounts ?? []);
+
+    // Remaining counts every unpaid peso, installments included — a statement
+    // is unpaid until all of its purchases are.
+    const remainingBills = sumBy(ordinaryRows, (b) =>
+      isOccurrencePaid(paidKeys, b._id, b.date) ? 0 : (b.amount ?? 0),
+    );
+    const remainingStatements = sumBy(statements, (s) =>
+      s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date))
+        ? 0
+        : s.amount,
+    );
+
+    // "Total Bills" counts a statement as one obligation, not N purchases —
+    // one payment is what the user actually makes.
+    const { bills: ordinaryAll, installments: installmentsAll } =
+      partitionBills(bills);
+    const accountsWithPurchases = new Set(
+      installmentsAll.map((b) => b.bnplAccountId),
+    );
+
+    // Nearest upcoming unpaid obligation of either kind.
+    const today = startOfDay(new Date());
+    const upcomingBill = ordinaryRows.find(
+      (b) =>
+        utcDateOnlyToLocal(b.date) >= today &&
+        !isOccurrencePaid(paidKeys, b._id, b.date),
+    );
+    const upcomingStatement = statements.find(
+      (s) =>
+        utcDateOnlyToLocal(s.date) >= today &&
+        !s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date)),
+    );
+
+    const candidates: Array<{ title: string; date: Date }> = [];
+    if (upcomingBill)
+      candidates.push({ title: upcomingBill.title, date: upcomingBill.date });
+    if (upcomingStatement)
+      candidates.push({
+        title: upcomingStatement.accountName,
+        date: upcomingStatement.date,
+      });
+    candidates.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    return {
+      remaining: remainingBills + remainingStatements,
+      nextItem: candidates[0] ?? null,
+      billCount: ordinaryAll.length + accountsWithPurchases.size,
+    };
+  }, [incomeProfile, bills, paidKeys, accounts]);
+```
+
+Update the two affected cards:
+
+```tsx
+    {
+      icon: FileText,
+      label: "Total Bills",
+      value: billCount.toString(),
+      subtitle: "Active bills",
+      mono: true,
+    },
+```
+
+```tsx
+    {
+      icon: CalendarClock,
+      label: "Next Bill",
+      value: nextItem?.title ?? "None",
+      subtitle: nextItem
+        ? formatUtcDate(nextItem.date, "MMM dd, yyyy")
+        : "No upcoming bills",
+      mono: false,
+    },
+```
+
+- [ ] **Step 2: Keep purchases out of the playground**
+
+In `src/components/playgroundStartScreen.tsx`, add the import:
+
+```tsx
+import { partitionBills } from "~/lib/bill-utils";
+```
+
+Change `handleCloneBills` so only ordinary bills are cloned. A purchase is a structurally valid recurring bill, so it would clone perfectly and reappear as individual rows in the one surface the design put out of scope:
+
+```tsx
+  const handleCloneBills = () => {
+    const { bills: ordinaryBills } = partitionBills(bills ?? []);
+    dispatch({ type: "INIT_CLONE", incomeProfile, bills: ordinaryBills });
+  };
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/components/financialSummaryCards.tsx src/components/playgroundStartScreen.tsx
+```
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS — all tests from Tasks 1–3.
+
+- [ ] **Step 5: Verify in the running app**
+
+1. With 2 ordinary bills and 3 purchases on one account, "Total Bills" reads **3** (2 bills + 1 account), not 5.
+2. "Remaining" drops by the statement amount when the statement is marked paid on `/bnpl`.
+3. "Next Bill" names the account when its statement is the soonest unpaid obligation.
+4. `/playground` → "clone my bills" brings in the ordinary bills only; no installments appear.
+5. `/dashboard` with only BNPL purchases and no ordinary bills still shows the period cards (not "No bills yet"), each with its roll-up row.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/financialSummaryCards.tsx src/components/playgroundStartScreen.tsx
+git commit -m "feat: count BNPL statements in summary cards, exclude from playground (#44)"
+```
+
+---
+
+## Done criteria
+
+- `pnpm test` passes; `pnpm exec tsc --noEmit` and `pnpm exec eslint src` are clean.
+- `/bnpl` creates accounts and purchases, shows one statement per account, and settles it with one toggle.
+- An account's installments never appear as individual rows in the pay-period list; each account contributes one dated roll-up row whose amount is included in that period's "going out".
+- Section subtotals plus roll-up amounts equal each period card's outgoing total.
+- Changing an account's due day moves every existing purchase, leaving exactly one statement per month.
+- No file in `src/` contains the string "Shopee" or "SPayLater" outside of placeholder/example copy.

--- a/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
+++ b/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
@@ -1461,7 +1461,7 @@ const AccountFormSchema = z.object({
   dueDay: z.coerce.number().int().min(1).max(31),
 });
 
-type AccountFormValues = z.infer<typeof AccountFormSchema>;
+export type AccountFormValues = z.infer<typeof AccountFormSchema>;
 
 export function BnplAccountFormDialog({
   open,
@@ -1569,7 +1569,10 @@ import { toast } from "sonner";
 import { api } from "~/trpc/react";
 import type { BnplAccount } from "~/types";
 import { AuthenticatedLayout } from "./authenticatedLayout";
-import { BnplAccountFormDialog } from "./bnplAccountFormDialog";
+import {
+  BnplAccountFormDialog,
+  type AccountFormValues,
+} from "./bnplAccountFormDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1608,13 +1611,23 @@ export function BnplManager() {
   const [editing, setEditing] = useState<BnplAccount | null>(null);
   const [deleting, setDeleting] = useState<BnplAccount | null>(null);
 
-  // The delete dialog names the count so the consequence of each option is
+  // Both confirmation dialogs name a purchase count so their consequence is
   // concrete. Read from the shared bill list rather than a dedicated endpoint —
   // the page already needs those rows in Task 8.
   const { data: allBills } = api.bill.getAll.useQuery();
+  const purchaseCountFor = (accountId: string) =>
+    (allBills ?? []).filter((b) => b.bnplAccountId === accountId).length;
+
   const deletingPurchaseCount = deleting
-    ? (allBills ?? []).filter((b) => b.bnplAccountId === deleting._id).length
+    ? purchaseCountFor(deleting._id)
     : 0;
+
+  // A changed due day rewrites every existing purchase's schedule, which moves
+  // due dates the user may have set months ago. Held here until confirmed.
+  const [pendingDueDay, setPendingDueDay] = useState<{
+    account: BnplAccount;
+    values: AccountFormValues;
+  } | null>(null);
 
   const invalidate = () =>
     Promise.all([
@@ -1637,9 +1650,27 @@ export function BnplManager() {
       await invalidate();
       toast.success("Account updated");
       setEditing(null);
+      setPendingDueDay(null);
     },
     onError: (e) => toast.error(e.message || "Failed to update account"),
   });
+
+  // Saving an edit only prompts when the due day actually changed *and* there
+  // are purchases to move. A rename, or a due-day change on an empty account,
+  // saves straight through — a dialog with nothing at stake is just friction.
+  const handleEditSubmit = (values: AccountFormValues) => {
+    if (!editing) return;
+
+    const movesPurchases =
+      values.dueDay !== editing.dueDay && purchaseCountFor(editing._id) > 0;
+
+    if (movesPurchases) {
+      setPendingDueDay({ account: editing, values });
+      return;
+    }
+
+    updateMut.mutate({ id: editing._id, data: values });
+  };
 
   const deleteMut = api.bnpl.delete.useMutation({
     onSuccess: async () => {
@@ -1720,12 +1751,52 @@ export function BnplManager() {
         open={editing !== null}
         onOpenChange={(open) => !open && setEditing(null)}
         account={editing ?? undefined}
-        onSubmit={(values) => {
-          if (!editing) return;
-          updateMut.mutate({ id: editing._id, data: values });
-        }}
+        onSubmit={handleEditSubmit}
         isPending={updateMut.isPending}
       />
+
+      {/* Rendered above the still-open edit dialog, so cancelling returns to
+          the form with its values intact rather than discarding the edit. */}
+      <AlertDialog
+        open={pendingDueDay !== null}
+        onOpenChange={(open) => !open && setPendingDueDay(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Move the statement day?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDueDay &&
+                `${purchaseCountFor(pendingDueDay.account._id)} existing purchase${
+                  purchaseCountFor(pendingDueDay.account._id) === 1 ? "" : "s"
+                } will move from day ${pendingDueDay.account.dueDay} to day ${
+                  pendingDueDay.values.dueDay
+                }. Every statement date for this account changes to match, so it
+                stays a single monthly statement.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (pendingDueDay)
+                  updateMut.mutate({
+                    id: pendingDueDay.account._id,
+                    data: pendingDueDay.values,
+                  });
+              }}
+              disabled={updateMut.isPending}
+            >
+              {updateMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              Move purchases
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={deleting !== null}
@@ -1812,7 +1883,8 @@ Run `pnpm dev`, sign in, and confirm:
 1. **BNPL** appears in the nav and `/bnpl` loads.
 2. With no accounts, the empty state shows and its button opens the dialog.
 3. Creating an account named `SPayLater` with due day `15` lists it as "Due day 15".
-4. Editing the name and due day persists after a reload.
+4. Editing the name and due day persists after a reload — and **no**
+   confirmation appears, because this account has no purchases to move.
 5. Deleting an account with no purchases offers only "Delete account" and
    removes it; "Keep purchases as ordinary bills" is disabled.
 
@@ -2471,7 +2543,10 @@ With `pnpm dev`, on `/bnpl`:
 2. Add a second purchase `Fan`, `700`, `3` months, same month. The statement becomes `₱1,950` — one line, not two.
 3. Mark the statement paid: the amount strikes through, both purchases count as paid.
 4. Add a third purchase in the same month — the statement flips back to unpaid (expected).
-5. Edit the **account's** due day from 15 to 20 and reload: the statement date moves to the 20th and stays a *single* statement.
+5. Edit the **account's** due day from 15 to 20. A confirmation names the
+   purchases that will move, from day 15 to day 20. Cancel it — nothing changes
+   and the edit form is still open with day 20 in it. Confirm it, then reload:
+   the statement date has moved to the 20th and is still a *single* statement.
 6. Set the due day to 31 and add a purchase whose first month is February: the statement lands on Feb 28.
 7. Delete a purchase, confirming its dialog.
 8. Delete the account choosing **Keep purchases as ordinary bills** — the

--- a/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
+++ b/docs/superpowers/plans/2026-08-26-bnpl-accounts.md
@@ -709,16 +709,18 @@ git commit -m "feat: add BNPL statement grouping and installment progress (#44)"
 
 **Files:**
 - Create: `src/schemas/bnpl.ts`
+- Create: `src/server/api/bill-cascade.ts`
 - Create: `src/server/api/routers/bnpl.ts`
 - Modify: `src/server/api/root.ts`
 
 **Interfaces:**
 - Consumes: `deriveStatementDtstart` (Task 1), `BnplAccount` (Task 3).
 - Produces:
+  - `deleteBillsWithPayments(db, userOid, billOids): Promise<number>` — used again in Task 5.
   - `bnpl.getAll` → `BnplAccount[]`, sorted by `_id`.
   - `bnpl.create({ name, dueDay })` → `BnplAccount`.
   - `bnpl.update({ id, data: { name?, dueDay? } })` → `void`.
-  - `bnpl.delete({ id })` → `void`.
+  - `bnpl.delete({ id, purchases: "delete" | "keep" })` → `void`.
   - Exported from `bnpl.ts` for Task 5: `type BnplAccountDoc`, `assertAccountOwned(ctx, accountId)`.
   - Zod schemas in `src/schemas/bnpl.ts`, extended in Task 5.
 
@@ -753,7 +755,13 @@ export const UpdateBnplAccountInputSchema = z.object({
   }),
 });
 
-export const DeleteBnplAccountInputSchema = z.object({ id: z.string() });
+// `purchases` has no default on purpose: deleting an account is destructive in
+// one direction and merely untidy in the other, so the caller must state which
+// it wants rather than inheriting a choice made here.
+export const DeleteBnplAccountInputSchema = z.object({
+  id: z.string(),
+  purchases: z.enum(["delete", "keep"]),
+});
 
 export type CreateBnplAccountInput = z.infer<
   typeof CreateBnplAccountInputSchema
@@ -763,7 +771,50 @@ export type UpdateBnplAccountInput = z.infer<
 >;
 ```
 
-- [ ] **Step 2: Write the router**
+- [ ] **Step 2: Create the shared cascade helper**
+
+Create `src/server/api/bill-cascade.ts`. Both the account delete below and the
+bill router (Task 5) need it, so it lands here rather than being written twice.
+
+```ts
+import type { Db, ObjectId } from "mongodb";
+
+/**
+ * Delete bills together with the paid-occurrence markers pointing at them.
+ *
+ * A `payments` document is a small marker meaning "this bill's occurrence on
+ * this date is settled" — it carries no amount, only that pairing. Occurrences
+ * are generated from a bill's recurrence rather than stored, so a marker is
+ * only meaningful while its bill exists. Deleting a bill without its markers
+ * leaves rows nothing can render and nothing can clear.
+ *
+ * Shared by the bill router and the BNPL router: purchases are `bills` rows,
+ * but their mutations live in the BNPL router, so without this helper the same
+ * rule would be written twice and remembered once.
+ *
+ * Returns the number of bills actually deleted, so callers can distinguish
+ * "not found" from "deleted".
+ */
+export async function deleteBillsWithPayments(
+  db: Db,
+  userOid: ObjectId,
+  billOids: ObjectId[],
+): Promise<number> {
+  if (billOids.length === 0) return 0;
+
+  const result = await db
+    .collection("bills")
+    .deleteMany({ _id: { $in: billOids }, userId: userOid });
+
+  await db
+    .collection("payments")
+    .deleteMany({ userId: userOid, billId: { $in: billOids } });
+
+  return result.deletedCount;
+}
+```
+
+- [ ] **Step 3: Write the router**
 
 Create `src/server/api/routers/bnpl.ts`:
 
@@ -776,6 +827,7 @@ import {
   DeleteBnplAccountInputSchema,
   UpdateBnplAccountInputSchema,
 } from "~/schemas/bnpl";
+import { deleteBillsWithPayments } from "../bill-cascade";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 // DB representation — ObjectId fields. See ~/types `BnplAccount` for the
@@ -924,28 +976,38 @@ export const bnplRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
 
-      // Cascade rather than unset: leaving the purchases behind as ordinary
-      // bills would make every installment materialize as its own row in the
-      // pay-period list.
-      const cursor = ctx.db
-        .collection<{ _id: ObjectId }>("bills")
-        .find(
-          { userId: userOid, bnplAccountId: accountOid },
-          { projection: { _id: 1 } },
-        );
-      const purchases = await cursor.toArray();
-      await cursor.close();
+      if (input.purchases === "delete") {
+        const cursor = ctx.db
+          .collection<{ _id: ObjectId }>("bills")
+          .find(
+            { userId: userOid, bnplAccountId: accountOid },
+            { projection: { _id: 1 } },
+          );
+        const purchases = await cursor.toArray();
+        await cursor.close();
 
-      const billOids = purchases.map((p) => p._id);
-      if (billOids.length > 0) {
+        await deleteBillsWithPayments(
+          ctx.db,
+          userOid,
+          purchases.map((p) => p._id),
+        );
+      } else {
+        // Keep: drop only the account reference, so each purchase becomes an
+        // ordinary monthly recurring bill. Its `count` still ends it at the
+        // close of its tenure.
+        //
+        // `payments` is deliberately untouched — the bill ids don't change, so
+        // every existing paid-marker stays valid and correctly attached.
         await ctx.db
           .collection("bills")
-          .deleteMany({ _id: { $in: billOids }, userId: userOid });
-        await ctx.db
-          .collection("payments")
-          .deleteMany({ userId: userOid, billId: { $in: billOids } });
+          .updateMany(
+            { userId: userOid, bnplAccountId: accountOid },
+            { $unset: { bnplAccountId: "" } },
+          );
       }
 
+      // Purchases are handled first so a failure here can be retried without
+      // having already orphaned them — the same ordering as `group.delete`.
       await ctx.db
         .collection<BnplAccountDoc>("bnpl_accounts")
         .deleteOne({ _id: accountOid, userId: userOid });
@@ -953,7 +1015,7 @@ export const bnplRouter = createTRPCRouter({
 });
 ```
 
-- [ ] **Step 3: Register the router**
+- [ ] **Step 4: Register the router**
 
 In `src/server/api/root.ts`, add the import and the entry:
 
@@ -972,82 +1034,39 @@ export const appRouter = createTRPCRouter({
 });
 ```
 
-- [ ] **Step 4: Typecheck and lint**
+- [ ] **Step 5: Typecheck and lint**
 
 ```bash
 pnpm exec tsc --noEmit
-pnpm exec eslint src/schemas/bnpl.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
+pnpm exec eslint src/schemas/bnpl.ts src/server/api/bill-cascade.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
 ```
 
 Expected: both clean. The `input.data.dueDay!` non-null assertion inside the `flatMap` is guarded by the `undefined` early-return above it; if the lint config forbids `!`, hoist it instead: `const nextDueDay = input.data.dueDay;` before the early return, then use `nextDueDay`.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/schemas/bnpl.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
+git add src/schemas/bnpl.ts src/server/api/bill-cascade.ts src/server/api/routers/bnpl.ts src/server/api/root.ts
 git commit -m "feat: add BNPL account router with due-day schedule rewrite (#44)"
 ```
 
 ---
 
-## Task 5: Shared cascade helper and purchase mutations
+## Task 5: Purchase mutations
 
 **Files:**
-- Create: `src/server/api/bill-cascade.ts`
 - Modify: `src/server/api/routers/bill.ts:120-146`
 - Modify: `src/server/api/routers/bnpl.ts`
 - Modify: `src/schemas/bnpl.ts`
 
 **Interfaces:**
-- Consumes: `assertAccountOwned`, `BnplAccountDoc` (Task 4), `deriveStatementDtstart` (Task 1).
+- Consumes: `assertAccountOwned`, `BnplAccountDoc`, `deleteBillsWithPayments` (Task 4), `deriveStatementDtstart` (Task 1).
 - Produces:
-  - `deleteBillsWithPayments(db, userOid, billOids): Promise<number>`.
   - `bnpl.createPurchase({ accountId, title, amount, tenureMonths, firstDueMonth })` → `void`.
   - `bnpl.updatePurchase({ id, data: { title, amount, tenureMonths, firstDueMonth } })` → `void`.
   - `bnpl.deletePurchase({ id })` → `void`.
 
-- [ ] **Step 1: Extract the cascade helper**
-
-Create `src/server/api/bill-cascade.ts`:
-
-```ts
-import type { Db, ObjectId } from "mongodb";
-
-/**
- * Delete bills together with the paid-occurrence markers pointing at them.
- *
- * Occurrences aren't stored rows — they're generated from a bill's recurrence —
- * so a `payments` document is only meaningful while its bill exists. Deleting a
- * bill without its payments leaves markers that can never be rendered or
- * cleared.
- *
- * Shared by the bill router and the BNPL router: purchases are `bills` rows, but
- * their mutations live in the BNPL router, so without this helper the same rule
- * would be written twice and remembered once.
- *
- * Returns the number of bills actually deleted, so callers can distinguish "not
- * found" from "deleted".
- */
-export async function deleteBillsWithPayments(
-  db: Db,
-  userOid: ObjectId,
-  billOids: ObjectId[],
-): Promise<number> {
-  if (billOids.length === 0) return 0;
-
-  const result = await db
-    .collection("bills")
-    .deleteMany({ _id: { $in: billOids }, userId: userOid });
-
-  await db
-    .collection("payments")
-    .deleteMany({ userId: userOid, billId: { $in: billOids } });
-
-  return result.deletedCount;
-}
-```
-
-- [ ] **Step 2: Use it in the bill router**
+- [ ] **Step 1: Use the shared cascade in the bill router**
 
 In `src/server/api/routers/bill.ts`, add the import:
 
@@ -1077,20 +1096,7 @@ Replace the body of the `delete` procedure (currently the `deleteOne` plus the t
     }),
 ```
 
-- [ ] **Step 3: Use it in the account delete**
-
-In `src/server/api/routers/bnpl.ts`, add the import and replace the two `deleteMany` calls written in Task 4 with the helper:
-
-```ts
-import { deleteBillsWithPayments } from "../bill-cascade";
-```
-
-```ts
-      const billOids = purchases.map((p) => p._id);
-      await deleteBillsWithPayments(ctx.db, userOid, billOids);
-```
-
-- [ ] **Step 4: Add the purchase schemas**
+- [ ] **Step 2: Add the purchase schemas**
 
 Append to `src/schemas/bnpl.ts`:
 
@@ -1126,7 +1132,7 @@ export type UpdateBnplPurchaseInput = z.infer<
 >;
 ```
 
-- [ ] **Step 5: Add the purchase mutations**
+- [ ] **Step 3: Add the purchase mutations**
 
 In `src/server/api/routers/bnpl.ts`, extend the imports:
 
@@ -1231,23 +1237,23 @@ Add these procedures inside `bnplRouter`:
     }),
 ```
 
-- [ ] **Step 6: Typecheck and lint**
+- [ ] **Step 4: Typecheck and lint**
 
 ```bash
 pnpm exec tsc --noEmit
-pnpm exec eslint src/server/api/bill-cascade.ts src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
+pnpm exec eslint src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
 ```
 
-- [ ] **Step 7: Run the existing tests**
+- [ ] **Step 5: Run the existing tests**
 
 Run: `pnpm test`
 Expected: PASS — nothing in Tasks 1–3 should be affected.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/server/api/bill-cascade.ts src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
-git commit -m "feat: add BNPL purchase mutations and shared bill cascade (#44)"
+git add src/server/api/routers/bill.ts src/server/api/routers/bnpl.ts src/schemas/bnpl.ts
+git commit -m "feat: add BNPL purchase mutations (#44)"
 ```
 
 ---
@@ -1602,6 +1608,14 @@ export function BnplManager() {
   const [editing, setEditing] = useState<BnplAccount | null>(null);
   const [deleting, setDeleting] = useState<BnplAccount | null>(null);
 
+  // The delete dialog names the count so the consequence of each option is
+  // concrete. Read from the shared bill list rather than a dedicated endpoint —
+  // the page already needs those rows in Task 8.
+  const { data: allBills } = api.bill.getAll.useQuery();
+  const deletingPurchaseCount = deleting
+    ? (allBills ?? []).filter((b) => b.bnplAccountId === deleting._id).length
+    : 0;
+
   const invalidate = () =>
     Promise.all([
       utils.bnpl.getAll.invalidate(),
@@ -1721,26 +1735,48 @@ export function BnplManager() {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete {deleting?.name}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This also deletes every purchase under this account and its
-              payment history. This cannot be undone.
+              {deletingPurchaseCount === 0
+                ? "This account has no purchases."
+                : `This account has ${deletingPurchaseCount} purchase${
+                    deletingPurchaseCount === 1 ? "" : "s"
+                  }. Choose what happens to them.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteMut.isPending}>
-              Cancel
-            </AlertDialogCancel>
+          {/* Two outcomes rather than one default: deleting destroys purchase
+              and payment history, while keeping destroys nothing and only puts
+              those rows back in the bill list. Neither is obviously right, so
+              the choice is made here, in view of the count. */}
+          <AlertDialogFooter className="sm:flex-col sm:gap-2">
             <AlertDialogAction
+              className="w-full"
               onClick={(e) => {
                 e.preventDefault();
-                if (deleting) deleteMut.mutate({ id: deleting._id });
+                if (deleting)
+                  deleteMut.mutate({ id: deleting._id, purchases: "keep" });
+              }}
+              disabled={deleteMut.isPending || deletingPurchaseCount === 0}
+            >
+              Keep purchases as ordinary bills
+            </AlertDialogAction>
+            <AlertDialogAction
+              className="w-full"
+              onClick={(e) => {
+                e.preventDefault();
+                if (deleting)
+                  deleteMut.mutate({ id: deleting._id, purchases: "delete" });
               }}
               disabled={deleteMut.isPending}
             >
               {deleteMut.isPending && (
                 <Loader2 className="mr-1 size-4 animate-spin" />
               )}
-              Delete
+              {deletingPurchaseCount === 0
+                ? "Delete account"
+                : "Delete purchases too"}
             </AlertDialogAction>
+            <AlertDialogCancel className="w-full" disabled={deleteMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -1777,7 +1813,8 @@ Run `pnpm dev`, sign in, and confirm:
 2. With no accounts, the empty state shows and its button opens the dialog.
 3. Creating an account named `SPayLater` with due day `15` lists it as "Due day 15".
 4. Editing the name and due day persists after a reload.
-5. Deleting it asks for confirmation and removes it.
+5. Deleting an account with no purchases offers only "Delete account" and
+   removes it; "Keep purchases as ordinary bills" is disabled.
 
 - [ ] **Step 7: Commit**
 
@@ -2185,10 +2222,11 @@ import {
 } from "./bnplPurchaseFormDialog";
 ```
 
-Add the queries and derivations inside `BnplManager`, after the existing `accounts` query:
+Add the queries and derivations inside `BnplManager`, after the existing
+`accounts` query. Note `allBills` already exists from Task 7 — reuse it rather
+than declaring a second variable for the same query:
 
 ```tsx
-  const { data: bills } = api.bill.getAll.useQuery();
   const { data: payments } = api.payment.getAll.useQuery();
 
   const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
@@ -2197,7 +2235,7 @@ Add the queries and derivations inside `BnplManager`, after the existing `accoun
   // rather than re-deriving dates here — one scheduler, one set of clamping
   // rules. A 14-month window is enough to always contain the next statement.
   const { purchasesByAccount, statementByAccount } = useMemo(() => {
-    const { installments } = partitionBills(bills ?? []);
+    const { installments } = partitionBills(allBills ?? []);
     // Already UTC midnight — localDateToUtcDateOnly maps today's local
     // calendar day onto the canonical frame the scheduler anchors on.
     const windowStart = localDateToUtcDateOnly(new Date());
@@ -2226,7 +2264,7 @@ Add the queries and derivations inside `BnplManager`, after the existing `accoun
     }
 
     return { purchasesByAccount, statementByAccount };
-  }, [bills, accounts]);
+  }, [allBills, accounts]);
 ```
 
 Add the purchase and statement mutations alongside the existing account mutations:
@@ -2435,7 +2473,13 @@ With `pnpm dev`, on `/bnpl`:
 4. Add a third purchase in the same month — the statement flips back to unpaid (expected).
 5. Edit the **account's** due day from 15 to 20 and reload: the statement date moves to the 20th and stays a *single* statement.
 6. Set the due day to 31 and add a purchase whose first month is February: the statement lands on Feb 28.
-7. Delete a purchase, then delete the account, confirming both dialogs.
+7. Delete a purchase, confirming its dialog.
+8. Delete the account choosing **Keep purchases as ordinary bills** — the
+   account disappears and its purchases now show as individual rows on
+   `/dashboard`, with any paid state preserved.
+9. Recreate an account with a purchase and delete it choosing **Delete purchases
+   too** — both the account and its purchases are gone from `/bnpl` and
+   `/dashboard`.
 
 - [ ] **Step 6: Commit**
 
@@ -2751,4 +2795,5 @@ git commit -m "feat: count BNPL statements in summary cards, exclude from playgr
 - An account's installments never appear as individual rows in the pay-period list; each account contributes one dated roll-up row whose amount is included in that period's "going out".
 - Section subtotals plus roll-up amounts equal each period card's outgoing total.
 - Changing an account's due day moves every existing purchase, leaving exactly one statement per month.
+- Deleting an account offers both outcomes: "delete purchases too" removes them and their paid-markers; "keep as ordinary bills" leaves them in the bill list with their paid history intact.
 - No file in `src/` contains the string "Shopee" or "SPayLater" outside of placeholder/example copy.

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -234,15 +234,22 @@ split statement the derivation exists to prevent, so the mutation that changes
 `dueDay` must also rewrite `dtstart` on every purchase belonging to that
 account.
 
-### 2. Deleting an account cascades
+### 2. Deleting an account asks what to do with its purchases
 
-Deletion removes the account, its purchases, *and* their `payments` documents,
-following the cascade already in `bill.delete`. A confirmation dialog names the
-purchase count first.
+The confirmation dialog names the purchase count and offers two outcomes:
 
-Unsetting `bnplAccountId` instead would turn every installment into an ordinary
-bill, which would then materialize as individual rows in the pay-period list —
-the exact clutter this feature removes.
+- **Delete purchases too** — the account, its purchases, and their paid-markers
+  are all removed, via the shared cascade helper (see case 4).
+- **Keep as ordinary bills** — `bnplAccountId` is unset. The purchases survive
+  as plain monthly recurring bills and begin appearing as individual rows in the
+  pay-period list. Their `count` still ends them at the close of their tenure,
+  and their paid-markers stay valid because the bill ids never change — so this
+  path deliberately does **not** touch `payments`.
+
+Neither outcome dominates, which is why both are offered instead of one being
+chosen here. Cascading destroys real purchase and payment history. Unsetting
+destroys nothing and merely costs tidiness — the bill list gets those rows back.
+That trade belongs to the person doing the deleting, at the moment they do it.
 
 ### 3. Due days 29–31 clamp to month end
 
@@ -255,22 +262,39 @@ so derivation clamps backward instead: Feb 28, or Feb 29 in a leap year.
 needs attention is that the **first** date — `dtstart` itself — is computed with
 the same clamping, rather than assuming the generator will cover it.
 
-### 4. Deleting a single purchase cascades its payments
+### 4. Deleting a single purchase also deletes its paid-markers
 
-Deleting an ordinary bill also deletes that bill's `payments` rows, or paid
-markers would outlive the bill they point at. A purchase is a bill, so it needs
-the same cleanup — but purchase mutations live in `bnplRouter` (keeping
-`billRouter` unable to mint or manage BNPL items), so `bnplRouter` does not
-inherit it.
+Background: marking something paid does not modify the bill. It writes a tiny
+separate document into the `payments` collection that says, in effect, *"bill X,
+the occurrence on date Y, is settled."* It holds no amount — just that pairing.
+Paid state is the presence of such a marker; unpaid is its absence.
 
-Rather than duplicating the cascade in both routers, extract it into a **shared
-helper** that both call, so the rule lives in one place.
+That means deleting a bill without deleting its markers leaves rows pointing at
+a bill that no longer exists. Nothing can render them, and nothing can clear
+them; they simply accumulate. `bill.delete` already avoids this by removing both
+together.
 
-### 5. Every `bill.getAll` consumer is accounted for
+A purchase is a bill, so it needs the same cleanup. But purchase deletion lives
+in `bnplRouter` — deliberately, so `billRouter` can never create or manage a
+BNPL item — which means `bnplRouter` does not get `bill.delete`'s cleanup for
+free.
 
-`bill.getAll` returns every bill, purchases included. Any consumer that assumes
-"these are all ordinary bills" leaks purchases back into a list as individual
-rows. The sweep is done, and two consumers deliberately need no change:
+Writing the same two-step delete in both routers would mean one rule living in
+two places, correct only as long as both are remembered. Instead it is extracted
+into a **shared helper** that both routers call.
+
+### 5. Every screen that reads the bill list is accounted for
+
+Purchases are stored in the same `bills` collection as ordinary bills, so the
+single query the whole app uses to fetch bills — `bill.getAll` — returns both
+kinds mixed together. Any screen that takes that result and assumes every row is
+an ordinary bill will render purchases as individual rows, which is exactly the
+clutter this feature exists to remove.
+
+`partitionBills` is the fix, but it only helps where it is actually called. So
+every consumer of `bill.getAll` was checked, and the result is below rather than
+left as "remember to look during implementation". Two of them correctly need no
+change, for opposite reasons:
 
 | Consumer                                   | Action                                                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -221,24 +221,75 @@ Account ownership is validated on every write, following the existing
 
 ## Edge cases
 
-1. **Changing an account's `dueDay` recomputes every one of its purchases'
-   `dtstart`**, in the same mutation. Without this, existing purchases keep the
-   old day and the account silently splits into two statements — defeating the
-   derivation.
-2. **Deleting an account cascades** to its purchases *and* their `payments`
-   documents, following the cascade already in `bill.delete`. Unsetting
-   `bnplAccountId` instead would turn installments into ordinary bills that
-   suddenly materialize in the pay-period list. A confirmation dialog names the
-   purchase count first.
-3. **`dtstart` derivation clamps to month end** (see Model).
-4. A fully-elapsed purchase stops generating occurrences via `count`; it sorts
-   last on the account card with a "Done" badge.
-5. An account with no purchases shows ₱0 committed and produces no roll-up row.
-6. Deleting a single purchase cascades its `payments` documents. This happens
-   in `bnplRouter`, which must implement the cascade itself — it does not route
-   through `bill.delete`.
-7. All `bill.getAll` consumers must be swept for the partition during
-   implementation, not just the three named above.
+### 1. Changing an account's due day rewrites its purchases
+
+Say a SPayLater account has `dueDay: 15` and three purchases, each stored with
+`dtstart` on the 15th. The due day then changes to 20 — the provider moved the
+cycle, or the original value was a typo.
+
+Updating only the account document leaves the three existing purchases
+generating occurrences on the 15th while new ones generate on the 20th. The
+dashboard would then show **two** SPayLater rows in the same month. That is the
+split statement the derivation exists to prevent, so the mutation that changes
+`dueDay` must also rewrite `dtstart` on every purchase belonging to that
+account.
+
+### 2. Deleting an account cascades
+
+Deletion removes the account, its purchases, *and* their `payments` documents,
+following the cascade already in `bill.delete`. A confirmation dialog names the
+purchase count first.
+
+Unsetting `bnplAccountId` instead would turn every installment into an ordinary
+bill, which would then materialize as individual rows in the pay-period list —
+the exact clutter this feature removes.
+
+### 3. Due days 29–31 clamp to month end
+
+`dueDay` may be 31, but not every month has a 31st. With `dueDay: 31` and
+February as the first month, there is no Feb 31 to store. Rolling forward to
+Mar 3 would place the statement in the wrong month and skip February entirely,
+so derivation clamps backward instead: Feb 28, or Feb 29 in a leap year.
+
+`monthlyOccurrencesInPeriod` already clamps the occurrences it generates. What
+needs attention is that the **first** date — `dtstart` itself — is computed with
+the same clamping, rather than assuming the generator will cover it.
+
+### 4. Deleting a single purchase cascades its payments
+
+Deleting an ordinary bill also deletes that bill's `payments` rows, or paid
+markers would outlive the bill they point at. A purchase is a bill, so it needs
+the same cleanup — but purchase mutations live in `bnplRouter` (keeping
+`billRouter` unable to mint or manage BNPL items), so `bnplRouter` does not
+inherit it.
+
+Rather than duplicating the cascade in both routers, extract it into a **shared
+helper** that both call, so the rule lives in one place.
+
+### 5. Every `bill.getAll` consumer is accounted for
+
+`bill.getAll` returns every bill, purchases included. Any consumer that assumes
+"these are all ordinary bills" leaks purchases back into a list as individual
+rows. The sweep is done, and two consumers deliberately need no change:
+
+| Consumer                                   | Action                                                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `billList.tsx:354`                         | **Partition** — group rows vs roll-up row                                                               |
+| `financialSummaryCards.tsx`                | **Partition** — a statement counts as 1                                                                 |
+| `playgroundStartScreen.tsx:31`             | **Partition** — "clone my bills" would otherwise drag purchases into the playground as loose bills       |
+| `dashboardPage.tsx:133`                    | **No change, deliberately** — `hasBills` must count purchases, or a BNPL-only user sees "No bills yet"   |
+| `groupManager.tsx:232`                     | **No change** — already filters on `groupId`, which purchases never carry                                |
+| `billModal`, `billViewMode`, `createBillForm` | **No change** — invalidation only; roll-up rows are not clickable                                     |
+
+`playgroundStartScreen` is the subtle one: a purchase clones perfectly into the
+playground *because* it is a structurally valid recurring bill, reappearing as
+individual rows in the one surface declared out of scope.
+
+### 6. Lesser cases
+
+- A fully-elapsed purchase stops generating occurrences via `count`; it sorts
+  last on the account card with a "Done" badge.
+- An account with no purchases shows ₱0 committed and produces no roll-up row.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -234,6 +234,11 @@ split statement the derivation exists to prevent, so the mutation that changes
 `dueDay` must also rewrite `dtstart` on every purchase belonging to that
 account.
 
+Because that rewrite silently moves the due date on purchases entered months
+ago, it is **confirmed first**. Saving a changed due day opens a dialog naming
+how many purchases will move and which day they move from and to; the rewrite
+runs only on confirmation. Changing an account's name alone never prompts.
+
 ### 2. Deleting an account asks what to do with its purchases
 
 The confirmation dialog names the purchase count and offers two outcomes:

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -30,7 +30,7 @@ record rather than forgotten:
 - Payoff-progress reporting beyond a per-purchase "3 of 6" count.
 - Credit limits and utilization.
 - Provider presets (a curated list of BNPL brands with icons/colours).
-- Drag-reordering accounts.
+- Reordering accounts, and per-account colour coding.
 - Playground support — `PlaygroundBill` is local-only demo state and gains
   nothing from a second entity shape.
 
@@ -46,10 +46,15 @@ Many per user, one document per provider account.
 | `userId` | `ObjectId` |                                          |
 | `name`   | `string`   | Free text, e.g. "SPayLater". 1–50 chars. |
 | `dueDay` | `number`   | Day of month, 1–31.                      |
-| `order`  | `number`   | Stable sort order; `max + 1` on create.  |
 
-`order` exists so the list doesn't reshuffle between renders. There is no
-reorder UI in this pass.
+Accounts are listed in creation order via `.sort({ _id: 1 })`. There is
+deliberately **no `order` field**: ObjectIds are timestamp-prefixed, so `_id`
+already gives a stable insertion-order sort with nothing to write or keep
+consistent. `groups` carries `order` because it earns two jobs there — the
+drag-reorder mutation and `colorForOrder` swatch derivation — and neither
+applies here. Should reordering ever land, adding `order` then is
+migration-free: absent means "fall back to `_id` order", the same trick
+`bnplAccountId` relies on.
 
 ### Purchases: `bills` documents with `bnplAccountId`
 

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -239,6 +239,20 @@ ago, it is **confirmed first**. Saving a changed due day opens a dialog naming
 how many purchases will move and which day they move from and to; the rewrite
 runs only on confirmation. Changing an account's name alone never prompts.
 
+**The rewrite must also move the paid-markers.** Markers are keyed on
+`(billId, occurrenceDate)` (see case 4), and moving `dtstart` moves every
+occurrence date they point at. Left alone, every paid installment on the account
+would revert to reading unpaid, and the stale rows could never be cleared —
+`markUnpaid` needs the occurrence rendered before anyone can click it, which is
+the same unclearable state case 4 exists to prevent, arriving through the update
+path instead of the delete path.
+
+So the same mutation shifts each marker by the same transform it applied to
+`dtstart`: month kept, day replaced, clamped backward. This preserves paid
+history exactly, and it cannot collide — a bill produces at most one occurrence
+per month, so two markers for one bill always differ in month, and a transform
+that preserves the month keeps them distinct.
+
 ### 2. Deleting an account asks what to do with its purchases
 
 The confirmation dialog names the purchase count and offers two outcomes:
@@ -314,7 +328,32 @@ change, for opposite reasons:
 playground *because* it is a structurally valid recurring bill, reappearing as
 individual rows in the one surface declared out of scope.
 
-### 6. Lesser cases
+### 6. Editing a purchase can strand its paid-markers too
+
+Case 1 covers the due-day path, where the *day* moves and markers shift with it.
+Editing a purchase moves things case 1's reasoning does not cover, and the same
+harm follows:
+
+- **Changing the first month** moves every occurrence to a different month. The
+  markers cannot be shifted the way a day-change shifts them, because
+  installment 1 is now a different month — shifting would silently re-attribute
+  a payment made for March to the new installment 1. So the bill's markers are
+  **deleted**: the schedule was redefined, and prior paid records no longer
+  correspond to anything the user can see.
+- **Shrinking the tenure** leaves markers past the new final occurrence with
+  nothing to render them. Those, and only those, are deleted; markers for
+  installments that still exist stay valid.
+
+Without this, a purchase edited forward by a month shows its current statement
+as paid when it is not, and `Remaining` under-counts by that installment — a
+wrong number, not merely an orphaned row.
+
+This case was missed in the first draft of this spec and found by the
+whole-branch review. Note the pre-existing `bill.update` orphans markers the
+same way for ordinary recurring bills; that is out of scope here, but it is the
+same defect class.
+
+### 7. Lesser cases
 
 - A fully-elapsed purchase stops generating occurrences via `count`; it sorts
   last on the account card with a "Done" badge.

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -58,7 +58,7 @@ migration-free: absent means "fall back to `_id` order", the same trick
 
 ### Purchases: `bills` documents with `bnplAccountId`
 
-A BNPL purchase *is* a finite monthly recurring bill, so it reuses the existing
+A BNPL purchase _is_ a finite monthly recurring bill, so it reuses the existing
 `bills` collection and the scheduler that already serves it. One new optional
 field carries the whole distinction:
 
@@ -85,15 +85,33 @@ input schema — an installment with no amount can't contribute to a statement.
 ### Consolidation is structural
 
 `dtstart` is **derived server-side** from the account's `dueDay` plus the first
-due month the user picks. The client never sends it.
-
-This is the load-bearing decision in the design. If each purchase carried its
-own `dtstart`, the one-statement-per-month invariant would hold only as long as
-every entry was made carefully — a convention. Deriving it makes a split
-statement unrepresentable.
+due month the user picks. The client never sends it. If each purchase carried
+its own `dtstart`, the one-statement-per-month invariant would hold only as long
+as every entry was made carefully — a convention.
 
 Derivation clamps to month end, matching `monthlyOccurrencesInPeriod`: first
 month February with `dueDay: 31` yields Feb 28, not a roll into March.
+
+**Derivation alone is not sufficient, and the clamp is why.** A stored anchor
+keeps the clamped day, and `monthlyOccurrencesInPeriod` re-derives its target
+day from that anchor. So with `dueDay: 31`, a purchase first due in February is
+anchored on the 28th and fires on the 28th forever, while a sibling first due in
+March fires on the 31st — one account, two occurrence days, two statements a
+month. Derivation narrows the anchor to a single day per month; it does not make
+the series agree.
+
+The invariant is therefore enforced at the point statements are formed:
+`groupStatements` keys on **(account, calendar month)** and dates each statement
+at the account's `dueDay` clamped into that month, never at an occurrence's own
+day. Anchor drift becomes invisible rather than impossible, and one account can
+emit at most one statement per month regardless of what its purchases carry.
+Dating the statement from the account also puts every paid-marker for it on the
+same day, which is what lets the due-day marker shift (case 4) land exactly.
+
+The deeper fix — store only the first _month_ and derive the day at read time —
+would make drift unrepresentable and remove `bnpl.update`'s fan-out entirely.
+Deferred: it changes the stored shape, and month-grouping already holds the
+invariant.
 
 ## Scheduling and money math
 
@@ -137,8 +155,8 @@ Sep 15 – Sep 29                     +₱1,300
   LazPayLater (1)        Sep 20         ₱900
 ```
 
-This preserves the invariant the file documents today — *the sum of section
-subtotals equals the card's outgoing total* — which would otherwise break the
+This preserves the invariant the file documents today — _the sum of section
+subtotals equals the card's outgoing total_ — which would otherwise break the
 moment a counted amount stopped being itemized. The statement amount is derived
 from that month's active purchases, so it varies correctly as purchases finish.
 
@@ -148,14 +166,18 @@ month, so a fortnightly pay period holds zero or one roll-up row per account.
 ### `financialSummaryCards.tsx`
 
 - **Total Bills** — each account's statement counts as **1**, not N purchases.
-- **Remaining** — includes unpaid statements.
+- **Remaining** — includes each statement's **unpaid purchases**, not the whole
+  statement amount. A statement settled at ₱3,000 that then gains a ₱500
+  purchase (or a tenure increase) owes ₱500, not ₱3,500.
 - **Next Bill** — a statement competes with ordinary bills on date; when one
   wins, the card shows the account name and the statement amount.
 
 ### Paid state
 
 Paid is per **(account, statement date)**, not per purchase: you settle one
-statement, so one toggle. Accounts settle independently.
+statement, so one toggle. Accounts settle independently. The markers are still
+per purchase underneath, so a statement that gains a purchase after settlement
+reads unpaid again and owes only the new amount.
 
 New bulk procedures take an account id and a statement date and write (or
 delete) a `payments` document for each of that account's purchases due then:
@@ -180,7 +202,7 @@ split up front because `groupManager.tsx` is already 400+ lines.
 
 | File                                        | Responsibility                                        |
 | ------------------------------------------- | ----------------------------------------------------- |
-| `src/app/bnpl/page.tsx`                     | RSC shell, `force-dynamic`, renders `<BnplManager />`  |
+| `src/app/bnpl/page.tsx`                     | RSC shell, `force-dynamic`, renders `<BnplManager />` |
 | `src/components/bnplManager.tsx`            | Account list, empty state, orchestration              |
 | `src/components/bnplAccountCard.tsx`        | One account: header, current statement, its purchases |
 | `src/components/bnplAccountFormDialog.tsx`  | Create/edit account (name, due day)                   |
@@ -198,8 +220,11 @@ statement with its paid toggle, then its purchases with monthly amount and
 
 Two terms used above, defined once here:
 
-- **Current statement** — the account's next unelapsed due date (today's date
-  included), and the purchases with an installment falling on it.
+- **Current statement** — the account's earliest statement from the start of the
+  current month onward, and the purchases with an installment falling on it. The
+  window opens at the month start, not at today, so a statement whose due date
+  has passed unpaid stays on the card and settleable — `/bnpl` holds the only
+  statement toggle in the app, so dropping it there would strand it.
 - **Committed total** — the sum of `amount` across the purchases in the current
   statement. It is the statement's amount, and it shrinks as purchases finish.
 
@@ -284,8 +309,8 @@ the same clamping, rather than assuming the generator will cover it.
 ### 4. Deleting a single purchase also deletes its paid-markers
 
 Background: marking something paid does not modify the bill. It writes a tiny
-separate document into the `payments` collection that says, in effect, *"bill X,
-the occurrence on date Y, is settled."* It holds no amount — just that pairing.
+separate document into the `payments` collection that says, in effect, _"bill X,
+the occurrence on date Y, is settled."_ It holds no amount — just that pairing.
 Paid state is the presence of such a marker; unpaid is its absence.
 
 That means deleting a bill without deleting its markers leaves rows pointing at
@@ -315,22 +340,22 @@ every consumer of `bill.getAll` was checked, and the result is below rather than
 left as "remember to look during implementation". Two of them correctly need no
 change, for opposite reasons:
 
-| Consumer                                   | Action                                                                                                  |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `billList.tsx:354`                         | **Partition** — group rows vs roll-up row                                                               |
-| `financialSummaryCards.tsx`                | **Partition** — a statement counts as 1                                                                 |
-| `playgroundStartScreen.tsx:31`             | **Partition** — "clone my bills" would otherwise drag purchases into the playground as loose bills       |
-| `dashboardPage.tsx:133`                    | **No change, deliberately** — `hasBills` must count purchases, or a BNPL-only user sees "No bills yet"   |
-| `groupManager.tsx:232`                     | **No change** — already filters on `groupId`, which purchases never carry                                |
-| `billModal`, `billViewMode`, `createBillForm` | **No change** — invalidation only; roll-up rows are not clickable                                     |
+| Consumer                                      | Action                                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `billList.tsx:354`                            | **Partition** — group rows vs roll-up row                                                              |
+| `financialSummaryCards.tsx`                   | **Partition** — a statement counts as 1                                                                |
+| `playgroundStartScreen.tsx:31`                | **Partition** — "clone my bills" would otherwise drag purchases into the playground as loose bills     |
+| `dashboardPage.tsx:133`                       | **No change, deliberately** — `hasBills` must count purchases, or a BNPL-only user sees "No bills yet" |
+| `groupManager.tsx:232`                        | **No change** — already filters on `groupId`, which purchases never carry                              |
+| `billModal`, `billViewMode`, `createBillForm` | **No change** — invalidation only; roll-up rows are not clickable                                      |
 
 `playgroundStartScreen` is the subtle one: a purchase clones perfectly into the
-playground *because* it is a structurally valid recurring bill, reappearing as
+playground _because_ it is a structurally valid recurring bill, reappearing as
 individual rows in the one surface declared out of scope.
 
 ### 6. Editing a purchase can strand its paid-markers too
 
-Case 1 covers the due-day path, where the *day* moves and markers shift with it.
+Case 1 covers the due-day path, where the _day_ moves and markers shift with it.
 Editing a purchase moves things case 1's reasoning does not cover, and the same
 harm follows:
 

--- a/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
+++ b/docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md
@@ -1,0 +1,260 @@
+# BNPL Accounts — Design
+
+Issue: [#44](https://github.com/jedymatt/remindmebills/issues/44) — "add separate section for managing shopee's spaylater items"
+
+## Problem
+
+Buy-now-pay-later purchases (Shopee SPayLater, Lazada LazPayLater, and similar)
+can be entered today as ordinary recurring bills, but they clutter the
+pay-period bill list. A single month can hold a dozen installment rows that the
+user thinks of as one payment.
+
+They also don't behave like ordinary bills. A BNPL provider **consolidates**:
+every active purchase's installment for the month lands on one statement, with
+one due date and one payment. Modelling each purchase as an independently
+scheduled bill misrepresents both the schedule and the payment.
+
+## Goals
+
+- Manage BNPL purchases on their own page, out of the pay-period bill list.
+- Keep their money in the dashboard's totals, so projections stay honest.
+- Support multiple providers as first-class **accounts**, each with its own
+  billing cycle, settled independently.
+
+## Non-goals
+
+Deliberately excluded from this pass, and listed so the omissions are on the
+record rather than forgotten:
+
+- Interest, fees, or processing charges; original purchase price; total payable.
+- Payoff-progress reporting beyond a per-purchase "3 of 6" count.
+- Credit limits and utilization.
+- Provider presets (a curated list of BNPL brands with icons/colours).
+- Drag-reordering accounts.
+- Playground support — `PlaygroundBill` is local-only demo state and gains
+  nothing from a second entity shape.
+
+## Model
+
+### `bnpl_accounts` (new collection)
+
+Many per user, one document per provider account.
+
+| Field    | Type       | Notes                                    |
+| -------- | ---------- | ---------------------------------------- |
+| `_id`    | `ObjectId` |                                          |
+| `userId` | `ObjectId` |                                          |
+| `name`   | `string`   | Free text, e.g. "SPayLater". 1–50 chars. |
+| `dueDay` | `number`   | Day of month, 1–31.                      |
+| `order`  | `number`   | Stable sort order; `max + 1` on create.  |
+
+`order` exists so the list doesn't reshuffle between renders. There is no
+reorder UI in this pass.
+
+### Purchases: `bills` documents with `bnplAccountId`
+
+A BNPL purchase *is* a finite monthly recurring bill, so it reuses the existing
+`bills` collection and the scheduler that already serves it. One new optional
+field carries the whole distinction:
+
+```ts
+bnplAccountId?: ObjectId;   // present = BNPL installment, and says which account
+```
+
+Presence is the discriminator, so no separate `kind` enum is needed and the
+account's identity is stored exactly once. An absent field means an ordinary
+bill, so **existing documents need no migration**.
+
+A purchase is stored as:
+
+| Field        | Value                                                            |
+| ------------ | ---------------------------------------------------------------- |
+| `type`       | `"recurring"`                                                    |
+| `recurrence` | `{ type: "monthly", interval: 1, dtstart, count: tenureMonths }` |
+| `amount`     | The monthly installment. **Required** for purchases.             |
+| `groupId`    | Never set. Group UI is not offered for purchases.                |
+
+`amount` is optional on the shared bill schema but required by the purchase
+input schema — an installment with no amount can't contribute to a statement.
+
+### Consolidation is structural
+
+`dtstart` is **derived server-side** from the account's `dueDay` plus the first
+due month the user picks. The client never sends it.
+
+This is the load-bearing decision in the design. If each purchase carried its
+own `dtstart`, the one-statement-per-month invariant would hold only as long as
+every entry was made carefully — a convention. Deriving it makes a split
+statement unrepresentable.
+
+Derivation clamps to month end, matching `monthlyOccurrencesInPeriod`: first
+month February with `dueDay: 31` yields Feb 28, not a roll into March.
+
+## Scheduling and money math
+
+Because purchases live in `bills`, `computeBillsInPeriod` already generates
+their occurrences on the shared due date and they are already inside the period
+sums. "Counted but not listed" therefore needs **no new money plumbing** — only
+a partition at render time.
+
+```ts
+// src/lib/bill-utils.ts
+partitionBills<T extends { bnplAccountId?: string | null }>(
+  rows: T[],
+): { bills: T[]; installments: T[] }
+```
+
+Generic over the element type because two shapes need it: raw `BillEvent`s (the
+summary cards) and generated occurrence rows (`BillEvent & { date: Date }`, the
+bill list). One helper, destructured by every consumer rather than filtered ad
+hoc. A polymorphic collection rots when the filter is spelled out at each call
+site; this is the single narrow seam that prevents that.
+
+### `billList.tsx`
+
+`bills` feed the existing group sections. `installments` group by
+**(accountId, dueDate)** and render as one non-expandable roll-up row per
+account with a statement in that period:
+
+```
+Sep 15 – Sep 29                     +₱1,300
+₱18,000 coming in, ₱16,700 going out
+
+  Utilities (2)                       ₱3,500
+    Meralco              Sep 20       ₱2,800
+    Water                Sep 22         ₱700
+
+  Ungrouped (2)                       ₱9,000
+    Rent                 Sep 15       ₱8,000
+    Netflix              Sep 18       ₱1,000
+
+  SPayLater (3)          Sep 15       ₱4,200
+  LazPayLater (1)        Sep 20         ₱900
+```
+
+This preserves the invariant the file documents today — *the sum of section
+subtotals equals the card's outgoing total* — which would otherwise break the
+moment a counted amount stopped being itemized. The statement amount is derived
+from that month's active purchases, so it varies correctly as purchases finish.
+
+Consolidation means a given account contributes at most one statement date per
+month, so a fortnightly pay period holds zero or one roll-up row per account.
+
+### `financialSummaryCards.tsx`
+
+- **Total Bills** — each account's statement counts as **1**, not N purchases.
+- **Remaining** — includes unpaid statements.
+- **Next Bill** — a statement competes with ordinary bills on date; when one
+  wins, the card shows the account name and the statement amount.
+
+### Paid state
+
+Paid is per **(account, statement date)**, not per purchase: you settle one
+statement, so one toggle. Accounts settle independently.
+
+New bulk procedures take an account id and a statement date and write (or
+delete) a `payments` document for each of that account's purchases due then:
+
+- `payment.markStatementPaid`
+- `payment.markStatementUnpaid`
+
+Both validate that the account belongs to the requesting user before writing,
+mirroring `assertBillOwned` in the existing payment router. Bulk on the server
+rather than N mutations from the client. A statement reads as paid when every
+purchase due that date has a payment, which also yields exact per-purchase
+progress on the page for free.
+
+**Known behaviour:** adding a purchase to a month already marked paid makes that
+statement read unpaid again. This is intended — more is genuinely owed — but it
+is a decision, not an accident.
+
+## Pages and components
+
+Mirrors the Groups pattern (thin RSC page delegating to one client component),
+split up front because `groupManager.tsx` is already 400+ lines.
+
+| File                                        | Responsibility                                        |
+| ------------------------------------------- | ----------------------------------------------------- |
+| `src/app/bnpl/page.tsx`                     | RSC shell, `force-dynamic`, renders `<BnplManager />`  |
+| `src/components/bnplManager.tsx`            | Account list, empty state, orchestration              |
+| `src/components/bnplAccountCard.tsx`        | One account: header, current statement, its purchases |
+| `src/components/bnplAccountFormDialog.tsx`  | Create/edit account (name, due day)                   |
+| `src/components/bnplPurchaseFormDialog.tsx` | Create/edit purchase                                  |
+| `src/server/api/routers/bnpl.ts`            | Account CRUD + purchase mutations                     |
+| `src/schemas/bnpl.ts`                       | Zod inputs, mirroring `schemas/group.ts`              |
+
+Route `/bnpl`; nav label **BNPL**, between Groups and Playground. No identifier
+in the codebase names a specific provider — issue #44 is satisfied by SPayLater
+being the first account the user creates.
+
+An account card shows: name, `Due the 15th`, the committed total, the current
+statement with its paid toggle, then its purchases with monthly amount and
+`3 of 6` progress.
+
+Two terms used above, defined once here:
+
+- **Current statement** — the account's next unelapsed due date (today's date
+  included), and the purchases with an installment falling on it.
+- **Committed total** — the sum of `amount` across the purchases in the current
+  statement. It is the statement's amount, and it shrinks as purchases finish.
+
+The purchase form collects **title, monthly amount, tenure in months, and first
+due month**. It never collects a day — that comes from the account.
+
+Purchase mutations live in `bnplRouter`, **not** `billRouter`, even though they
+write to `bills`. `bill.create` accepts a raw recurrence; a purchase must have
+its `dtstart` derived. Keeping `billRouter`'s contract unchanged means it cannot
+mint a BNPL item by accident.
+
+Account ownership is validated on every write, following the existing
+`resolveGroupId` pattern in `bill.ts`.
+
+### Types
+
+`src/types/index.ts` gains `BnplAccount`, and `BillEvent` gains
+`bnplAccountId?: string | null`.
+
+## Edge cases
+
+1. **Changing an account's `dueDay` recomputes every one of its purchases'
+   `dtstart`**, in the same mutation. Without this, existing purchases keep the
+   old day and the account silently splits into two statements — defeating the
+   derivation.
+2. **Deleting an account cascades** to its purchases *and* their `payments`
+   documents, following the cascade already in `bill.delete`. Unsetting
+   `bnplAccountId` instead would turn installments into ordinary bills that
+   suddenly materialize in the pay-period list. A confirmation dialog names the
+   purchase count first.
+3. **`dtstart` derivation clamps to month end** (see Model).
+4. A fully-elapsed purchase stops generating occurrences via `count`; it sorts
+   last on the account card with a "Done" badge.
+5. An account with no purchases shows ₱0 committed and produces no roll-up row.
+6. Deleting a single purchase cascades its `payments` documents. This happens
+   in `bnplRouter`, which must implement the cascade itself — it does not route
+   through `bill.delete`.
+7. All `bill.getAll` consumers must be swept for the partition during
+   implementation, not just the three named above.
+
+## Verification
+
+The repo has no test framework. This feature introduces **Vitest** covering only
+the pure helpers — the logic where manual clicking verifies worst:
+
+- `dtstart` derivation, including month-end clamping (Feb + day 31, Apr + day
+  31, day 28 in every month).
+- `partitionBills`.
+- Statement grouping by (account, date).
+
+Adds `vitest` as a dev dependency, a config file, and a `test` script. UI is
+verified by driving the running app (the project's `verify` skill).
+
+Note: `pnpm check` and `pnpm lint` are unreliable under Next 16 (`next lint` is
+removed) — run `tsc --noEmit` and `eslint` directly.
+
+## Future direction
+
+The non-goals fit this model without rework. Interest, purchase price, and
+credit limits are all **account-level or purchase-level attributes**, so they
+accumulate on `bnpl_accounts` documents or on the purchase input without the
+bill schema learning about them, and without disturbing the money-math wiring
+established here.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint:fix": "next lint --fix",
     "preview": "next build && next start",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -74,7 +76,8 @@
     "tailwindcss": "^4.2.2",
     "type-fest": "^5.5.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.58.0"
+    "typescript-eslint": "^8.58.0",
+    "vitest": "^4.1.11"
   },
   "ct3aMetadata": {
     "initVersion": "7.39.3"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.11.1",
+    "@date-fns/utc": "^2.1.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@auth/mongodb-adapter':
         specifier: ^3.11.1
         version: 3.11.1(mongodb@6.21.0)
+      '@date-fns/utc':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -288,6 +291,9 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@date-fns/utc@2.1.1':
+    resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -3757,6 +3763,8 @@ snapshots:
   '@better-fetch/fetch@1.1.21': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@date-fns/utc@2.1.1': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: 11.16.0(typescript@5.9.3)
       better-auth:
         specifier: ^1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(mongodb@6.21.0)(next@16.2.2(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.6.0(@opentelemetry/api@1.9.1)(mongodb@6.21.0)(next@16.2.2(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -180,6 +180,9 @@ importers:
       typescript-eslint:
         specifier: ^8.58.0
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1))
 
 packages:
 
@@ -635,6 +638,9 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -1399,6 +1405,99 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1568,6 +1667,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1752,6 +1857,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1811,6 +1945,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1947,6 +2085,10 @@ packages:
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1970,6 +2112,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -2071,6 +2216,9 @@ packages:
   es-iterator-helpers@1.3.1:
     resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2208,9 +2356,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2259,6 +2414,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2535,8 +2695,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -2547,8 +2719,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -2559,8 +2743,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2571,8 +2767,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2583,8 +2791,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2595,8 +2815,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   locate-path@6.0.0:
@@ -2684,6 +2914,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -2762,6 +2997,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2793,6 +3032,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2804,12 +3046,20 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -2995,6 +3245,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
@@ -3074,6 +3329,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -3089,6 +3347,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3164,9 +3428,24 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3273,6 +3552,90 @@ packages:
       typescript:
         optional: true
 
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -3300,6 +3663,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3688,6 +4056,8 @@ snapshots:
   '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@oxc-project/types@0.146.0': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -4491,6 +4861,53 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -4614,6 +5031,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -4791,6 +5215,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@20.19.39)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4883,6 +5348,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4901,7 +5368,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.16: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(mongodb@6.21.0)(next@16.2.2(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(mongodb@6.21.0)(next@16.2.2(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1))):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -4925,6 +5392,7 @@ snapshots:
       next: 16.2.2(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4974,6 +5442,8 @@ snapshots:
 
   caniuse-lite@1.0.30001786: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4994,6 +5464,8 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -5156,6 +5628,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5376,7 +5850,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5399,6 +5879,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5423,6 +5907,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -5701,34 +6188,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -5746,6 +6266,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   locate-path@6.0.0:
     dependencies:
@@ -5802,6 +6338,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.18: {}
 
   nanostores@1.2.0: {}
 
@@ -5890,6 +6428,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5923,17 +6463,27 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.7: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6112,6 +6662,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.2.5:
+    dependencies:
+      '@oxc-project/types': 0.146.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
+
   rou3@0.7.12: {}
 
   rrule@2.8.1:
@@ -6239,6 +6810,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -6251,6 +6824,10 @@ snapshots:
       memory-pager: 1.5.0
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6334,10 +6911,21 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6477,6 +7065,46 @@ snapshots:
       typescript: 5.9.3
     optional: true
 
+  vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@20.19.39)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@20.19.39)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@7.0.0: {}
 
   whatwg-url@14.2.0:
@@ -6528,6 +7156,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -211,8 +211,11 @@ function BillListCard({
     [installments, accounts],
   );
 
-  // Installments are counted here but itemized as one roll-up row per account
-  // below, so section subtotals plus statement amounts still equal `outgoing`.
+  // Paid bills and installments both stay in this sum rather than dropping out:
+  // paid shows as a struck row instead (balance is income−all-bills, not "cash
+  // left" — "remaining to pay" lives in the summary cards), and installments are
+  // itemized as one roll-up row per account below, so section subtotals plus
+  // statement amounts still equal `outgoing`.
   const outgoing = useMemo(
     () =>
       sumBy(

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -5,6 +5,7 @@ import { sumBy } from "lodash";
 import {
   Circle,
   CircleCheckBig,
+  CreditCard,
   EyeClosedIcon,
   EyeIcon,
   Sparkles,
@@ -12,13 +13,14 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BillModal } from "~/components/billModal";
-import { getPayPeriodsByCount } from "~/lib/bill-utils";
+import { getPayPeriodsByCount, partitionBills } from "~/lib/bill-utils";
+import { groupStatements } from "~/lib/bnpl-utils";
 import { formatUtcDate } from "~/lib/date-utils";
 import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
 import { UNGROUPED_COLOR, colorForOrder } from "~/lib/group-colors";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
-import type { BillEvent, Group } from "~/types";
+import type { BillEvent, BnplAccount, Group } from "~/types";
 
 function formatPHP(value: number, signDisplay?: "always") {
   return value.toLocaleString("en-PH", {
@@ -170,6 +172,7 @@ function BillRowItem({
 function BillListCard({
   bills,
   groups,
+  accounts,
   payDate,
   after,
   isCurrent,
@@ -181,6 +184,7 @@ function BillListCard({
 }: {
   bills: BillRow[];
   groups: Group[];
+  accounts: BnplAccount[];
   payDate: Date;
   after: Date | null;
   isCurrent: boolean;
@@ -192,11 +196,23 @@ function BillListCard({
 }) {
   const [excludedBills, setExcludedBills] = useState<string[]>([]);
 
-  const sections = useMemo(() => buildSections(bills, groups), [bills, groups]);
+  const { bills: ordinaryBills, installments } = useMemo(
+    () => partitionBills(bills),
+    [bills],
+  );
 
-  // Paid occurrences stay in the period sums — the card balance is a stable
-  // income−all-bills projection, not "cash left". Paid is shown as a struck row;
-  // "remaining to pay" lives in the summary cards instead.
+  const sections = useMemo(
+    () => buildSections(ordinaryBills, groups),
+    [ordinaryBills, groups],
+  );
+
+  const statements = useMemo(
+    () => groupStatements(installments, accounts),
+    [installments, accounts],
+  );
+
+  // Installments are counted here but itemized as one roll-up row per account
+  // below, so section subtotals plus statement amounts still equal `outgoing`.
   const outgoing = useMemo(
     () =>
       sumBy(
@@ -270,7 +286,7 @@ function BillListCard({
 
       {/* Sections */}
       <div className="flex-1 px-5 pb-5">
-        {bills.length === 0 ? (
+        {ordinaryBills.length === 0 && statements.length === 0 ? (
           <div className="flex flex-col items-center gap-2 py-8 text-center">
             <Sparkles className="text-muted-foreground/40 size-5" />
             <p className="text-muted-foreground text-sm">
@@ -340,6 +356,34 @@ function BillListCard({
                 </div>
               );
             })}
+
+            {statements.map((statement, idx) => (
+              <div
+                key={`${statement.accountId}:${statement.date.getTime()}`}
+                className={cn(
+                  (sections.length > 0 || idx > 0) &&
+                    "border-border/40 border-t pt-5",
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <CreditCard className="text-muted-foreground size-3.5 shrink-0" />
+                    <span className="text-foreground text-sm font-semibold">
+                      {statement.accountName}
+                    </span>
+                    <span className="bg-muted/60 text-muted-foreground ml-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
+                      {statement.purchaseCount}
+                    </span>
+                    <span className="text-muted-foreground ml-1 font-mono text-[11px] tabular-nums">
+                      {formatUtcDate(statement.date, "MMM d")}
+                    </span>
+                  </div>
+                  <span className="w-24 text-right font-mono text-sm font-medium tracking-tight tabular-nums">
+                    {formatPHP(statement.amount)}
+                  </span>
+                </div>
+              </div>
+            ))}
           </div>
         )}
       </div>
@@ -354,6 +398,7 @@ export function BillList() {
   const { data: bills } = api.bill.getAll.useQuery();
   const { data: incomeProfile } = api.income.getIncomeProfile.useQuery();
   const { data: groups } = api.group.getAll.useQuery();
+  const { data: accounts } = api.bnpl.getAll.useQuery();
   const { data: payments } = api.payment.getAll.useQuery();
   const utils = api.useUtils();
   const markPaid = api.payment.markPaid.useMutation();
@@ -386,7 +431,7 @@ export function BillList() {
     return () => observer.disconnect();
   }, [billsInPayPeriod.length]);
 
-  if (!incomeProfile || !bills || !groups) return null;
+  if (!incomeProfile || !bills || !groups || !accounts) return null;
 
   const ingoing = incomeProfile.amount ?? 0;
 
@@ -432,6 +477,7 @@ export function BillList() {
             payDate={payDate}
             bills={bills}
             groups={groups}
+            accounts={accounts}
             after={after}
             isCurrent={index === 0}
             ingoing={ingoing}

--- a/src/app/_components/billList.tsx
+++ b/src/app/_components/billList.tsx
@@ -14,7 +14,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BillModal } from "~/components/billModal";
 import { getPayPeriodsByCount, partitionBills } from "~/lib/bill-utils";
-import { groupStatements } from "~/lib/bnpl-utils";
+import {
+  groupStatements,
+  isStatementPaid,
+  statementKey,
+} from "~/lib/bnpl-utils";
 import { formatUtcDate } from "~/lib/date-utils";
 import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
 import { UNGROUPED_COLOR, colorForOrder } from "~/lib/group-colors";
@@ -360,33 +364,57 @@ function BillListCard({
               );
             })}
 
-            {statements.map((statement, idx) => (
-              <div
-                key={`${statement.accountId}:${statement.date.getTime()}`}
-                className={cn(
-                  (sections.length > 0 || idx > 0) &&
-                    "border-border/40 border-t pt-5",
-                )}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-1.5">
-                    <CreditCard className="text-muted-foreground size-3.5 shrink-0" />
-                    <span className="text-foreground text-sm font-semibold">
-                      {statement.accountName}
-                    </span>
-                    <span className="bg-muted/60 text-muted-foreground ml-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
-                      {statement.purchaseCount}
-                    </span>
-                    <span className="text-muted-foreground ml-1 font-mono text-[11px] tabular-nums">
-                      {formatUtcDate(statement.date, "MMM d")}
+            {statements.map((statement, idx) => {
+              // Settled statements read as settled here too. Without this a paid
+              // statement was indistinguishable from an unpaid one while the
+              // ordinary bills beside it struck through and the summary card
+              // above already reported it as ₱0 remaining. Read-only: the
+              // statement toggle itself lives on /bnpl.
+              const isPaid = isStatementPaid(paidKeys, statement);
+
+              return (
+                <div
+                  key={statementKey(statement.accountId, statement.date)}
+                  className={cn(
+                    (sections.length > 0 || idx > 0) &&
+                      "border-border/40 border-t pt-5",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "flex items-center justify-between",
+                      isPaid && "opacity-40",
+                    )}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <CreditCard className="text-muted-foreground size-3.5 shrink-0" />
+                      <span
+                        className={cn(
+                          "text-foreground text-sm font-semibold",
+                          isPaid && "line-through",
+                        )}
+                      >
+                        {statement.accountName}
+                      </span>
+                      <span className="bg-muted/60 text-muted-foreground ml-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
+                        {statement.items.length}
+                      </span>
+                      <span className="text-muted-foreground ml-1 font-mono text-[11px] tabular-nums">
+                        {formatUtcDate(statement.date, "MMM d")}
+                      </span>
+                    </div>
+                    <span
+                      className={cn(
+                        "w-24 text-right font-mono text-sm font-medium tracking-tight tabular-nums",
+                        isPaid && "line-through",
+                      )}
+                    >
+                      {formatPHP(statement.amount)}
                     </span>
                   </div>
-                  <span className="w-24 text-right font-mono text-sm font-medium tracking-tight tabular-nums">
-                    {formatPHP(statement.amount)}
-                  </span>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -434,7 +462,11 @@ export function BillList() {
     return () => observer.disconnect();
   }, [billsInPayPeriod.length]);
 
-  if (!incomeProfile || !bills || !groups || !accounts) return null;
+  // `accounts` is deliberately NOT in this guard: a failed or slow `bnpl.getAll`
+  // must not blank the entire pay-period grid for users who have no BNPL
+  // accounts at all. Statements simply fall back to their unnamed form until it
+  // arrives, exactly as the summary cards already do.
+  if (!incomeProfile || !bills || !groups) return null;
 
   const ingoing = incomeProfile.amount ?? 0;
 
@@ -480,7 +512,7 @@ export function BillList() {
             payDate={payDate}
             bills={bills}
             groups={groups}
-            accounts={accounts}
+            accounts={accounts ?? []}
             after={after}
             isCurrent={index === 0}
             ingoing={ingoing}

--- a/src/app/bnpl/page.tsx
+++ b/src/app/bnpl/page.tsx
@@ -1,0 +1,7 @@
+import { BnplManager } from "~/components/bnplManager";
+
+export const dynamic = "force-dynamic";
+
+export default function BnplPage() {
+  return <BnplManager />;
+}

--- a/src/components/authenticatedLayout.tsx
+++ b/src/components/authenticatedLayout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, type PropsWithChildren } from "react";
 import {
+  CreditCard,
   FlaskConical,
   FolderTree,
   LayoutDashboard,
@@ -100,6 +101,7 @@ function UserNav() {
 const navLinks: Array<{ href: string; label: string; icon: LucideIcon }> = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/groups", label: "Groups", icon: FolderTree },
+  { href: "/bnpl", label: "BNPL", icon: CreditCard },
   { href: "/playground", label: "Playground", icon: FlaskConical },
 ];
 
@@ -108,7 +110,7 @@ export function AuthenticatedLayout({ children }: PropsWithChildren) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
-    <div className="bg-ledger-paper text-ledger-ink font-sans flex min-h-svh flex-col antialiased">
+    <div className="bg-ledger-paper text-ledger-ink flex min-h-svh flex-col font-sans antialiased">
       <header className="border-ledger-line bg-ledger-paper/80 sticky top-0 z-50 w-full border-b backdrop-blur">
         <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
           <div className="flex items-center gap-6">

--- a/src/components/bnplAccountCard.tsx
+++ b/src/components/bnplAccountCard.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Circle, CircleCheckBig, Pencil, Plus, Trash2 } from "lucide-react";
+import { installmentProgress, type Statement } from "~/lib/bnpl-utils";
+import { formatUtcDate } from "~/lib/date-utils";
+import { cn } from "~/lib/utils";
+import type { BillEvent, BnplAccount } from "~/types";
+import { Button } from "./ui/button";
+
+function formatPHP(value: number) {
+  return value.toLocaleString("en-PH", {
+    style: "currency",
+    currency: "PHP",
+  });
+}
+
+export function BnplAccountCard({
+  account,
+  purchases,
+  statement,
+  isStatementPaid,
+  isStatementPending,
+  onToggleStatementPaid,
+  onEditAccount,
+  onDeleteAccount,
+  onAddPurchase,
+  onEditPurchase,
+  onDeletePurchase,
+}: {
+  account: BnplAccount;
+  purchases: BillEvent[];
+  statement: Statement | null;
+  isStatementPaid: boolean;
+  isStatementPending: boolean;
+  onToggleStatementPaid: () => void;
+  onEditAccount: () => void;
+  onDeleteAccount: () => void;
+  onAddPurchase: () => void;
+  onEditPurchase: (purchase: BillEvent) => void;
+  onDeletePurchase: (purchase: BillEvent) => void;
+}) {
+  return (
+    <div className="border-border/40 bg-card flex flex-col overflow-hidden rounded-3xl border">
+      <div className="flex items-start justify-between px-5 pt-5 pb-3">
+        <div>
+          <p className="text-foreground font-semibold">{account.name}</p>
+          <p className="text-muted-foreground font-mono text-xs tabular-nums">
+            Due day {account.dueDay}
+          </p>
+          {statement ? (
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                className={cn(
+                  "shrink-0 transition-colors disabled:opacity-50",
+                  isStatementPaid
+                    ? "text-ledger-accent-strong dark:text-ledger-accent"
+                    : "text-muted-foreground/50 hover:text-muted-foreground",
+                )}
+                onClick={onToggleStatementPaid}
+                disabled={isStatementPending}
+                aria-label={
+                  isStatementPaid
+                    ? "Mark statement unpaid"
+                    : "Mark statement paid"
+                }
+                aria-pressed={isStatementPaid}
+              >
+                {isStatementPaid ? (
+                  <CircleCheckBig className="size-4" />
+                ) : (
+                  <Circle className="size-4" />
+                )}
+              </button>
+              <span
+                className={cn(
+                  "font-mono text-2xl font-semibold tracking-tight tabular-nums",
+                  isStatementPaid && "line-through opacity-50",
+                )}
+              >
+                {formatPHP(statement.amount)}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                due {formatUtcDate(statement.date, "MMM d")}
+              </span>
+            </div>
+          ) : (
+            <p className="text-muted-foreground mt-3 text-sm">
+              Nothing due — no active purchases.
+            </p>
+          )}
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Edit account"
+            onClick={onEditAccount}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete account"
+            onClick={onDeleteAccount}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="px-5 pb-5">
+        <ul className="divide-border/40 divide-y">
+          {purchases.map((purchase) => {
+            if (purchase.type !== "recurring") return null;
+            const { elapsed, total } = installmentProgress(
+              purchase.recurrence.dtstart,
+              purchase.recurrence.count,
+              statement?.date ?? new Date(),
+            );
+            const isDone = elapsed >= total;
+
+            return (
+              <li
+                key={purchase._id}
+                className={cn(
+                  "flex items-center gap-3 py-2",
+                  isDone && "opacity-50",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {purchase.title}
+                  </div>
+                  <div className="text-muted-foreground font-mono text-[11px] tabular-nums">
+                    {isDone ? "Done" : `${elapsed} of ${total}`}
+                  </div>
+                </div>
+                <span className="w-24 shrink-0 text-right font-mono text-sm font-semibold tabular-nums">
+                  {formatPHP(purchase.amount ?? 0)}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Edit purchase"
+                  onClick={() => onEditPurchase(purchase)}
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Delete purchase"
+                  onClick={() => onDeletePurchase(purchase)}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={onAddPurchase}
+        >
+          Add purchase <Plus className="ml-1 size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bnplAccountCard.tsx
+++ b/src/components/bnplAccountCard.tsx
@@ -113,11 +113,21 @@ export function BnplAccountCard({
       <div className="px-5 pb-5">
         <ul className="divide-border/40 divide-y">
           {purchases.map((purchase) => {
-            if (purchase.type !== "recurring") return null;
+            // A purchase is always created recurring with a dtstart, but the
+            // BNPL router's own queries treat both as optional (legacy or
+            // partially-written rows), and `installmentProgress` would throw on
+            // an absent dtstart — taking the whole page down rather than one row.
+            if (purchase.type !== "recurring" || !purchase.recurrence.dtstart) {
+              return null;
+            }
+            // Anchored on today, not on the upcoming statement: the statement is
+            // the *next* one due, so measuring against it reports one
+            // installment more than has actually been billed and greys a
+            // purchase as "Done" a month before its final charge.
             const { elapsed, total } = installmentProgress(
               purchase.recurrence.dtstart,
               purchase.recurrence.count,
-              statement?.date ?? localDateToUtcDateOnly(new Date()),
+              localDateToUtcDateOnly(new Date()),
             );
             const isDone = elapsed >= total;
 

--- a/src/components/bnplAccountCard.tsx
+++ b/src/components/bnplAccountCard.tsx
@@ -2,7 +2,7 @@
 
 import { Circle, CircleCheckBig, Pencil, Plus, Trash2 } from "lucide-react";
 import { installmentProgress, type Statement } from "~/lib/bnpl-utils";
-import { formatUtcDate } from "~/lib/date-utils";
+import { formatUtcDate, localDateToUtcDateOnly } from "~/lib/date-utils";
 import { cn } from "~/lib/utils";
 import type { BillEvent, BnplAccount } from "~/types";
 import { Button } from "./ui/button";
@@ -117,7 +117,7 @@ export function BnplAccountCard({
             const { elapsed, total } = installmentProgress(
               purchase.recurrence.dtstart,
               purchase.recurrence.count,
-              statement?.date ?? new Date(),
+              statement?.date ?? localDateToUtcDateOnly(new Date()),
             );
             const isDone = elapsed >= total;
 

--- a/src/components/bnplAccountFormDialog.tsx
+++ b/src/components/bnplAccountFormDialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import type { BnplAccount } from "~/types";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./ui/form";
+import { Input } from "./ui/input";
+
+const AccountFormSchema = z.object({
+  name: z.string().trim().min(1, { message: "Name is required" }).max(50),
+  dueDay: z.coerce.number<number>().int().min(1).max(31),
+});
+
+export type AccountFormValues = z.infer<typeof AccountFormSchema>;
+
+export function BnplAccountFormDialog({
+  open,
+  onOpenChange,
+  account,
+  onSubmit,
+  isPending,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  account?: BnplAccount;
+  onSubmit: (values: AccountFormValues) => void;
+  isPending: boolean;
+}) {
+  const form = useForm<AccountFormValues>({
+    resolver: zodResolver(AccountFormSchema),
+    defaultValues: { name: "", dueDay: 15 },
+  });
+
+  // Reset on open so an edit shows the current values and a create starts clean.
+  useEffect(() => {
+    if (!open) return;
+    form.reset(
+      account
+        ? { name: account.name, dueDay: account.dueDay }
+        : { name: "", dueDay: 15 },
+    );
+  }, [open, account, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{account ? "Edit account" : "New account"}</DialogTitle>
+          <DialogDescription>
+            A BNPL provider bills every purchase on one monthly statement.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+            id="bnpl-account-form"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="SPayLater" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="dueDay"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Statement due day</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} max={31} {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Months without this day use their last day instead.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="bnpl-account-form" disabled={isPending}>
+            {isPending && <Loader2 className="mr-1 size-4 animate-spin" />}
+            {account ? "Save" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bnplManager.tsx
+++ b/src/components/bnplManager.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { addMonths } from "date-fns";
 import { CreditCard, Loader2, Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { computeBillsInPeriod, partitionBills } from "~/lib/bill-utils";
-import { groupStatements, type Statement } from "~/lib/bnpl-utils";
-import { localDateToUtcDateOnly } from "~/lib/date-utils";
-import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
+import {
+  groupStatements,
+  isStatementPaid,
+  statementBillIds,
+  statementKey,
+  type Statement,
+} from "~/lib/bnpl-utils";
+import {
+  addUtcMonths,
+  localDateToUtcDateOnly,
+  startOfUtcMonth,
+} from "~/lib/date-utils";
+import { buildPaidLookup } from "~/lib/payment-utils";
 import { api } from "~/trpc/react";
 import type { BillEvent, BnplAccount } from "~/types";
 import { AuthenticatedLayout } from "./authenticatedLayout";
@@ -60,12 +69,13 @@ export function BnplManager() {
 
   // Both confirmation dialogs name a purchase count so their consequence is
   // concrete. Read from the shared bill list rather than a dedicated endpoint —
-  // the page already needs those rows in Task 8.
+  // the page already needs those rows to render the account cards.
   const { data: allBills } = api.bill.getAll.useQuery();
-  const purchaseCountFor = (accountId: string) =>
-    (allBills ?? []).filter((b) => b.bnplAccountId === accountId).length;
-
-  const deletingPurchaseCount = deleting ? purchaseCountFor(deleting._id) : 0;
+  // Account cards render as soon as `bnpl.getAll` lands, which is typically
+  // before `bill.getAll`. Until the bills arrive a count of 0 would be a claim,
+  // not a fact — and both places that read it drive an irreversible action, so
+  // they must be blocked rather than shown a confident zero.
+  const purchasesLoaded = allBills !== undefined;
 
   const { data: payments } = api.payment.getAll.useQuery();
 
@@ -76,13 +86,16 @@ export function BnplManager() {
   // rules. A 14-month window is enough to always contain the next statement.
   const { purchasesByAccount, statementByAccount } = useMemo(() => {
     const { installments } = partitionBills(allBills ?? []);
-    // Already UTC midnight — localDateToUtcDateOnly maps today's local
-    // calendar day onto the canonical frame the scheduler anchors on.
-    const windowStart = localDateToUtcDateOnly(new Date());
+    // Anchored on the first of the current month, not on today: a statement
+    // whose due day has already passed is still the month's live obligation and
+    // this page holds the only toggle that can settle it. Starting at today
+    // dropped it from the window entirely, silently retargeting the toggle at
+    // next month's statement and leaving the current one unpayable forever.
+    const windowStart = startOfUtcMonth(localDateToUtcDateOnly(new Date()));
     const occurrences = computeBillsInPeriod(
       installments,
       windowStart,
-      addMonths(windowStart, 14),
+      addUtcMonths(windowStart, 14),
     );
     const statements = groupStatements(occurrences, accounts ?? []);
 
@@ -95,7 +108,7 @@ export function BnplManager() {
     }
 
     // The first statement per account is the current one, since groupStatements
-    // sorts by date and the window starts today.
+    // sorts by date and the window starts at the top of this month.
     const statementByAccount = new Map<string, (typeof statements)[number]>();
     for (const statement of statements) {
       if (!statementByAccount.has(statement.accountId)) {
@@ -105,6 +118,17 @@ export function BnplManager() {
 
     return { purchasesByAccount, statementByAccount };
   }, [allBills, accounts]);
+
+  // Derived from the map the memo above already built, rather than a second
+  // independent rescan of `allBills` with its own inlined predicate — the two
+  // could disagree about what counts as an installment, and the copy that
+  // drifted would mislabel a destructive confirmation.
+  const purchaseCountFor = useCallback(
+    (accountId: string) => purchasesByAccount.get(accountId)?.length ?? 0,
+    [purchasesByAccount],
+  );
+
+  const deletingPurchaseCount = deleting ? purchaseCountFor(deleting._id) : 0;
 
   // A changed due day rewrites every existing purchase's schedule, which moves
   // due dates the user may have set months ago. Held here until confirmed.
@@ -145,8 +169,17 @@ export function BnplManager() {
   const handleEditSubmit = (values: AccountFormValues) => {
     if (!editing) return;
 
-    const movesPurchases =
-      values.dueDay !== editing.dueDay && purchaseCountFor(editing._id) > 0;
+    const changesDueDay = values.dueDay !== editing.dueDay;
+
+    // Saving a due-day change with the purchase list still unknown would skip
+    // the confirmation and rewrite every schedule unannounced. Block instead of
+    // guessing zero.
+    if (changesDueDay && !purchasesLoaded) {
+      toast.error("Still loading purchases — try again in a moment");
+      return;
+    }
+
+    const movesPurchases = changesDueDay && purchaseCountFor(editing._id) > 0;
 
     if (movesPurchases) {
       setPendingDueDay({ account: editing, values });
@@ -218,43 +251,56 @@ export function BnplManager() {
     };
   }, [purchaseTarget?.purchase]);
 
-  const markStatementPaid = api.payment.markStatementPaid.useMutation();
-  const markStatementUnpaid = api.payment.markStatementUnpaid.useMutation();
+  // The pending key is cleared from the hook's own `onSettled`, derived from the
+  // variables of the call that settled. Passing per-call callbacks to `mutate`
+  // instead would strand the first key whenever a second toggle starts before
+  // the first resolves: both cards share one mutation observer, and it keeps
+  // only the most recent call's callbacks — leaving that card's button disabled
+  // for good.
+  const settleStatement = {
+    onSettled: (
+      _data: unknown,
+      error: unknown,
+      variables: { accountId: string; statementDate: Date },
+    ) => {
+      if (error) {
+        toast.error(
+          (error as { message?: string }).message ??
+            "Failed to update statement",
+        );
+      }
+      const key = statementKey(variables.accountId, variables.statementDate);
+      const clear = () =>
+        setPendingStatements((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      if (error) {
+        clear();
+        return;
+      }
+      void utils.payment.getAll.invalidate().finally(clear);
+    },
+  };
 
-  // A statement is paid only when every purchase on it is paid, so a purchase
-  // added after settling correctly flips it back to unpaid.
-  const isStatementPaid = (statement: Statement) =>
-    statement.billIds.every((billId) =>
-      paidKeys.has(occurrenceKey(billId, statement.date)),
-    );
+  const markStatementPaid =
+    api.payment.markStatementPaid.useMutation(settleStatement);
+  const markStatementUnpaid =
+    api.payment.markStatementUnpaid.useMutation(settleStatement);
 
   const handleToggleStatement = (statement: Statement) => {
-    const key = `${statement.accountId}:${statement.date.getTime()}`;
-    const currentlyPaid = isStatementPaid(statement);
-    setPendingStatements((prev) => new Set(prev).add(key));
-    const clearPending = () =>
-      setPendingStatements((prev) => {
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
+    const currentlyPaid = isStatementPaid(paidKeys, statement);
+    setPendingStatements((prev) =>
+      new Set(prev).add(statementKey(statement.accountId, statement.date)),
+    );
 
     const mutation = currentlyPaid ? markStatementUnpaid : markStatementPaid;
-    mutation.mutate(
-      {
-        accountId: statement.accountId,
-        statementDate: statement.date,
-        billIds: statement.billIds,
-      },
-      {
-        onSuccess: () =>
-          void utils.payment.getAll.invalidate().finally(clearPending),
-        onError: (error) => {
-          toast.error(error.message || "Failed to update statement");
-          clearPending();
-        },
-      },
-    );
+    mutation.mutate({
+      accountId: statement.accountId,
+      statementDate: statement.date,
+      billIds: statementBillIds(statement),
+    });
   };
 
   return (
@@ -281,9 +327,9 @@ export function BnplManager() {
           <div className="space-y-4">
             {accounts.map((account) => {
               const statement = statementByAccount.get(account._id) ?? null;
-              const statementKey = statement
-                ? `${statement.accountId}:${statement.date.getTime()}`
-                : "";
+              const pendingKey = statement
+                ? statementKey(statement.accountId, statement.date)
+                : null;
 
               return (
                 <BnplAccountCard
@@ -292,9 +338,11 @@ export function BnplManager() {
                   purchases={purchasesByAccount.get(account._id) ?? []}
                   statement={statement}
                   isStatementPaid={
-                    statement ? isStatementPaid(statement) : false
+                    statement ? isStatementPaid(paidKeys, statement) : false
                   }
-                  isStatementPending={pendingStatements.has(statementKey)}
+                  isStatementPending={
+                    pendingKey !== null && pendingStatements.has(pendingKey)
+                  }
                   onToggleStatementPaid={() =>
                     statement && handleToggleStatement(statement)
                   }
@@ -378,11 +426,13 @@ export function BnplManager() {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete {deleting?.name}?</AlertDialogTitle>
             <AlertDialogDescription>
-              {deletingPurchaseCount === 0
-                ? "This account has no purchases."
-                : `This account has ${deletingPurchaseCount} purchase${
-                    deletingPurchaseCount === 1 ? "" : "s"
-                  }. Choose what happens to them.`}
+              {!purchasesLoaded
+                ? "Checking what this account holds…"
+                : deletingPurchaseCount === 0
+                  ? "This account has no purchases."
+                  : `This account has ${deletingPurchaseCount} purchase${
+                      deletingPurchaseCount === 1 ? "" : "s"
+                    }. Choose what happens to them.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {/* Two outcomes rather than one default: deleting destroys purchase
@@ -397,7 +447,11 @@ export function BnplManager() {
                 if (deleting)
                   deleteMut.mutate({ id: deleting._id, purchases: "keep" });
               }}
-              disabled={deleteMut.isPending || deletingPurchaseCount === 0}
+              disabled={
+                deleteMut.isPending ||
+                !purchasesLoaded ||
+                deletingPurchaseCount === 0
+              }
             >
               Keep purchases as ordinary bills
             </AlertDialogAction>
@@ -408,7 +462,7 @@ export function BnplManager() {
                 if (deleting)
                   deleteMut.mutate({ id: deleting._id, purchases: "delete" });
               }}
-              disabled={deleteMut.isPending}
+              disabled={deleteMut.isPending || !purchasesLoaded}
             >
               {deleteMut.isPending && (
                 <Loader2 className="mr-1 size-4 animate-spin" />

--- a/src/components/bnplManager.tsx
+++ b/src/components/bnplManager.tsx
@@ -203,6 +203,21 @@ export function BnplManager() {
     onError: (e) => toast.error(e.message || "Failed to delete purchase"),
   });
 
+  // Memoized so identity is stable across unrelated re-renders (a react-query
+  // refetch, a sibling mutation's pending flip) — otherwise a new object every
+  // render would fire the dialog's reset effect and discard an in-progress
+  // edit. Keyed on the purchase being edited, plus the fields it reads.
+  const purchaseInitialValues = useMemo<PurchaseFormValues | undefined>(() => {
+    const purchase = purchaseTarget?.purchase;
+    if (purchase?.type !== "recurring") return undefined;
+    return {
+      title: purchase.title,
+      amount: purchase.amount ?? 0,
+      tenureMonths: purchase.recurrence.count ?? 1,
+      firstDueMonth: purchase.recurrence.dtstart,
+    };
+  }, [purchaseTarget?.purchase]);
+
   const markStatementPaid = api.payment.markStatementPaid.useMutation();
   const markStatementUnpaid = api.payment.markStatementUnpaid.useMutation();
 
@@ -387,7 +402,7 @@ export function BnplManager() {
               Keep purchases as ordinary bills
             </AlertDialogAction>
             <AlertDialogAction
-              className="w-full"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 w-full"
               onClick={(e) => {
                 e.preventDefault();
                 if (deleting)
@@ -416,16 +431,7 @@ export function BnplManager() {
         open={purchaseTarget !== null}
         onOpenChange={(open) => !open && setPurchaseTarget(null)}
         accountName={purchaseTarget?.account.name ?? ""}
-        initialValues={
-          purchaseTarget?.purchase?.type === "recurring"
-            ? {
-                title: purchaseTarget.purchase.title,
-                amount: purchaseTarget.purchase.amount ?? 0,
-                tenureMonths: purchaseTarget.purchase.recurrence.count ?? 1,
-                firstDueMonth: purchaseTarget.purchase.recurrence.dtstart,
-              }
-            : undefined
-        }
+        initialValues={purchaseInitialValues}
         onSubmit={(values: PurchaseFormValues) => {
           if (!purchaseTarget) return;
           if (purchaseTarget.purchase) {

--- a/src/components/bnplManager.tsx
+++ b/src/components/bnplManager.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { CreditCard, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { api } from "~/trpc/react";
+import type { BnplAccount } from "~/types";
+import { AuthenticatedLayout } from "./authenticatedLayout";
+import {
+  BnplAccountFormDialog,
+  type AccountFormValues,
+} from "./bnplAccountFormDialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
+import { Skeleton } from "./ui/skeleton";
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="border-ledger-line flex flex-col items-center rounded-lg border border-dashed py-12">
+      <span className="bg-ledger-accent-soft text-ledger-accent-strong mb-3 flex size-11 items-center justify-center rounded-2xl">
+        <CreditCard className="size-5" />
+      </span>
+      <h3 className="text-ledger-ink font-display text-lg">No BNPL accounts</h3>
+      <p className="text-ledger-muted mt-1 text-sm">
+        Add an account to track its installments separately from your bills.
+      </p>
+      <Button className="mt-4" onClick={onAdd}>
+        New Account <Plus className="ml-1 size-4" />
+      </Button>
+    </div>
+  );
+}
+
+export function BnplManager() {
+  const utils = api.useUtils();
+  const { data: accounts, isLoading } = api.bnpl.getAll.useQuery();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<BnplAccount | null>(null);
+  const [deleting, setDeleting] = useState<BnplAccount | null>(null);
+
+  // Both confirmation dialogs name a purchase count so their consequence is
+  // concrete. Read from the shared bill list rather than a dedicated endpoint —
+  // the page already needs those rows in Task 8.
+  const { data: allBills } = api.bill.getAll.useQuery();
+  const purchaseCountFor = (accountId: string) =>
+    (allBills ?? []).filter((b) => b.bnplAccountId === accountId).length;
+
+  const deletingPurchaseCount = deleting ? purchaseCountFor(deleting._id) : 0;
+
+  // A changed due day rewrites every existing purchase's schedule, which moves
+  // due dates the user may have set months ago. Held here until confirmed.
+  const [pendingDueDay, setPendingDueDay] = useState<{
+    account: BnplAccount;
+    values: AccountFormValues;
+  } | null>(null);
+
+  const invalidate = () =>
+    Promise.all([
+      utils.bnpl.getAll.invalidate(),
+      utils.bill.getAll.invalidate(),
+      utils.payment.getAll.invalidate(),
+    ]);
+
+  const createMut = api.bnpl.create.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account created");
+      setCreateOpen(false);
+    },
+    onError: (e) => toast.error(e.message || "Failed to create account"),
+  });
+
+  const updateMut = api.bnpl.update.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account updated");
+      setEditing(null);
+      setPendingDueDay(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to update account"),
+  });
+
+  // Saving an edit only prompts when the due day actually changed *and* there
+  // are purchases to move. A rename, or a due-day change on an empty account,
+  // saves straight through — a dialog with nothing at stake is just friction.
+  const handleEditSubmit = (values: AccountFormValues) => {
+    if (!editing) return;
+
+    const movesPurchases =
+      values.dueDay !== editing.dueDay && purchaseCountFor(editing._id) > 0;
+
+    if (movesPurchases) {
+      setPendingDueDay({ account: editing, values });
+      return;
+    }
+
+    updateMut.mutate({ id: editing._id, data: values });
+  };
+
+  const deleteMut = api.bnpl.delete.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Account deleted");
+      setDeleting(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to delete account"),
+  });
+
+  return (
+    <AuthenticatedLayout>
+      <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-ledger-ink font-display text-xl">BNPL</h1>
+          {accounts && accounts.length > 0 && (
+            <Button size="sm" onClick={() => setCreateOpen(true)}>
+              New Account <Plus className="ml-1 size-4" />
+            </Button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-3xl" />
+            ))}
+          </div>
+        ) : !accounts || accounts.length === 0 ? (
+          <EmptyState onAdd={() => setCreateOpen(true)} />
+        ) : (
+          <div className="space-y-4">
+            {accounts.map((account) => (
+              <div
+                key={account._id}
+                className="border-border/40 bg-card flex items-center justify-between rounded-3xl border p-5"
+              >
+                <div>
+                  <p className="text-foreground font-semibold">
+                    {account.name}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Due day {account.dueDay}
+                  </p>
+                </div>
+                <div className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Edit account"
+                    onClick={() => setEditing(account)}
+                  >
+                    <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Delete account"
+                    onClick={() => setDeleting(account)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <BnplAccountFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSubmit={(values) => createMut.mutate(values)}
+        isPending={createMut.isPending}
+      />
+
+      <BnplAccountFormDialog
+        open={editing !== null}
+        onOpenChange={(open) => !open && setEditing(null)}
+        account={editing ?? undefined}
+        onSubmit={handleEditSubmit}
+        isPending={updateMut.isPending}
+      />
+
+      {/* Rendered above the still-open edit dialog, so cancelling returns to
+          the form with its values intact rather than discarding the edit. */}
+      <AlertDialog
+        open={pendingDueDay !== null}
+        onOpenChange={(open) => !open && setPendingDueDay(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Move the statement day?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDueDay &&
+                `${purchaseCountFor(pendingDueDay.account._id)} existing purchase${
+                  purchaseCountFor(pendingDueDay.account._id) === 1 ? "" : "s"
+                } will move from day ${pendingDueDay.account.dueDay} to day ${
+                  pendingDueDay.values.dueDay
+                }. Every statement date for this account changes to match, so it
+                stays a single monthly statement.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (pendingDueDay)
+                  updateMut.mutate({
+                    id: pendingDueDay.account._id,
+                    data: pendingDueDay.values,
+                  });
+              }}
+              disabled={updateMut.isPending}
+            >
+              {updateMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              Move purchases
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={deleting !== null}
+        onOpenChange={(open) => !open && setDeleting(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {deleting?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deletingPurchaseCount === 0
+                ? "This account has no purchases."
+                : `This account has ${deletingPurchaseCount} purchase${
+                    deletingPurchaseCount === 1 ? "" : "s"
+                  }. Choose what happens to them.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {/* Two outcomes rather than one default: deleting destroys purchase
+              and payment history, while keeping destroys nothing and only puts
+              those rows back in the bill list. Neither is obviously right, so
+              the choice is made here, in view of the count. */}
+          <AlertDialogFooter className="sm:flex-col sm:gap-2">
+            <AlertDialogAction
+              className="w-full"
+              onClick={(e) => {
+                e.preventDefault();
+                if (deleting)
+                  deleteMut.mutate({ id: deleting._id, purchases: "keep" });
+              }}
+              disabled={deleteMut.isPending || deletingPurchaseCount === 0}
+            >
+              Keep purchases as ordinary bills
+            </AlertDialogAction>
+            <AlertDialogAction
+              className="w-full"
+              onClick={(e) => {
+                e.preventDefault();
+                if (deleting)
+                  deleteMut.mutate({ id: deleting._id, purchases: "delete" });
+              }}
+              disabled={deleteMut.isPending}
+            >
+              {deleteMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              {deletingPurchaseCount === 0
+                ? "Delete account"
+                : "Delete purchases too"}
+            </AlertDialogAction>
+            <AlertDialogCancel
+              className="w-full"
+              disabled={deleteMut.isPending}
+            >
+              Cancel
+            </AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/components/bnplManager.tsx
+++ b/src/components/bnplManager.tsx
@@ -1,15 +1,25 @@
 "use client";
 
-import { CreditCard, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { addMonths } from "date-fns";
+import { CreditCard, Loader2, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { computeBillsInPeriod, partitionBills } from "~/lib/bill-utils";
+import { groupStatements, type Statement } from "~/lib/bnpl-utils";
+import { localDateToUtcDateOnly } from "~/lib/date-utils";
+import { buildPaidLookup, occurrenceKey } from "~/lib/payment-utils";
 import { api } from "~/trpc/react";
-import type { BnplAccount } from "~/types";
+import type { BillEvent, BnplAccount } from "~/types";
 import { AuthenticatedLayout } from "./authenticatedLayout";
+import { BnplAccountCard } from "./bnplAccountCard";
 import {
   BnplAccountFormDialog,
   type AccountFormValues,
 } from "./bnplAccountFormDialog";
+import {
+  BnplPurchaseFormDialog,
+  type PurchaseFormValues,
+} from "./bnplPurchaseFormDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -56,6 +66,45 @@ export function BnplManager() {
     (allBills ?? []).filter((b) => b.bnplAccountId === accountId).length;
 
   const deletingPurchaseCount = deleting ? purchaseCountFor(deleting._id) : 0;
+
+  const { data: payments } = api.payment.getAll.useQuery();
+
+  const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+
+  // Statements are read off the same occurrence generator the dashboard uses,
+  // rather than re-deriving dates here — one scheduler, one set of clamping
+  // rules. A 14-month window is enough to always contain the next statement.
+  const { purchasesByAccount, statementByAccount } = useMemo(() => {
+    const { installments } = partitionBills(allBills ?? []);
+    // Already UTC midnight — localDateToUtcDateOnly maps today's local
+    // calendar day onto the canonical frame the scheduler anchors on.
+    const windowStart = localDateToUtcDateOnly(new Date());
+    const occurrences = computeBillsInPeriod(
+      installments,
+      windowStart,
+      addMonths(windowStart, 14),
+    );
+    const statements = groupStatements(occurrences, accounts ?? []);
+
+    const purchasesByAccount = new Map<string, BillEvent[]>();
+    for (const purchase of installments) {
+      if (!purchase.bnplAccountId) continue;
+      const list = purchasesByAccount.get(purchase.bnplAccountId) ?? [];
+      list.push(purchase);
+      purchasesByAccount.set(purchase.bnplAccountId, list);
+    }
+
+    // The first statement per account is the current one, since groupStatements
+    // sorts by date and the window starts today.
+    const statementByAccount = new Map<string, (typeof statements)[number]>();
+    for (const statement of statements) {
+      if (!statementByAccount.has(statement.accountId)) {
+        statementByAccount.set(statement.accountId, statement);
+      }
+    }
+
+    return { purchasesByAccount, statementByAccount };
+  }, [allBills, accounts]);
 
   // A changed due day rewrites every existing purchase's schedule, which moves
   // due dates the user may have set months ago. Held here until confirmed.
@@ -116,6 +165,83 @@ export function BnplManager() {
     onError: (e) => toast.error(e.message || "Failed to delete account"),
   });
 
+  const [purchaseTarget, setPurchaseTarget] = useState<{
+    account: BnplAccount;
+    purchase?: BillEvent;
+  } | null>(null);
+  const [deletingPurchase, setDeletingPurchase] = useState<BillEvent | null>(
+    null,
+  );
+  const [pendingStatements, setPendingStatements] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const createPurchaseMut = api.bnpl.createPurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase added");
+      setPurchaseTarget(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to add purchase"),
+  });
+
+  const updatePurchaseMut = api.bnpl.updatePurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase updated");
+      setPurchaseTarget(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to update purchase"),
+  });
+
+  const deletePurchaseMut = api.bnpl.deletePurchase.useMutation({
+    onSuccess: async () => {
+      await invalidate();
+      toast.success("Purchase deleted");
+      setDeletingPurchase(null);
+    },
+    onError: (e) => toast.error(e.message || "Failed to delete purchase"),
+  });
+
+  const markStatementPaid = api.payment.markStatementPaid.useMutation();
+  const markStatementUnpaid = api.payment.markStatementUnpaid.useMutation();
+
+  // A statement is paid only when every purchase on it is paid, so a purchase
+  // added after settling correctly flips it back to unpaid.
+  const isStatementPaid = (statement: Statement) =>
+    statement.billIds.every((billId) =>
+      paidKeys.has(occurrenceKey(billId, statement.date)),
+    );
+
+  const handleToggleStatement = (statement: Statement) => {
+    const key = `${statement.accountId}:${statement.date.getTime()}`;
+    const currentlyPaid = isStatementPaid(statement);
+    setPendingStatements((prev) => new Set(prev).add(key));
+    const clearPending = () =>
+      setPendingStatements((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+
+    const mutation = currentlyPaid ? markStatementUnpaid : markStatementPaid;
+    mutation.mutate(
+      {
+        accountId: statement.accountId,
+        statementDate: statement.date,
+        billIds: statement.billIds,
+      },
+      {
+        onSuccess: () =>
+          void utils.payment.getAll.invalidate().finally(clearPending),
+        onError: (error) => {
+          toast.error(error.message || "Failed to update statement");
+          clearPending();
+        },
+      },
+    );
+  };
+
   return (
     <AuthenticatedLayout>
       <div className="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
@@ -138,39 +264,35 @@ export function BnplManager() {
           <EmptyState onAdd={() => setCreateOpen(true)} />
         ) : (
           <div className="space-y-4">
-            {accounts.map((account) => (
-              <div
-                key={account._id}
-                className="border-border/40 bg-card flex items-center justify-between rounded-3xl border p-5"
-              >
-                <div>
-                  <p className="text-foreground font-semibold">
-                    {account.name}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    Due day {account.dueDay}
-                  </p>
-                </div>
-                <div className="flex gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Edit account"
-                    onClick={() => setEditing(account)}
-                  >
-                    <Pencil className="size-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Delete account"
-                    onClick={() => setDeleting(account)}
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                </div>
-              </div>
-            ))}
+            {accounts.map((account) => {
+              const statement = statementByAccount.get(account._id) ?? null;
+              const statementKey = statement
+                ? `${statement.accountId}:${statement.date.getTime()}`
+                : "";
+
+              return (
+                <BnplAccountCard
+                  key={account._id}
+                  account={account}
+                  purchases={purchasesByAccount.get(account._id) ?? []}
+                  statement={statement}
+                  isStatementPaid={
+                    statement ? isStatementPaid(statement) : false
+                  }
+                  isStatementPending={pendingStatements.has(statementKey)}
+                  onToggleStatementPaid={() =>
+                    statement && handleToggleStatement(statement)
+                  }
+                  onEditAccount={() => setEditing(account)}
+                  onDeleteAccount={() => setDeleting(account)}
+                  onAddPurchase={() => setPurchaseTarget({ account })}
+                  onEditPurchase={(purchase) =>
+                    setPurchaseTarget({ account, purchase })
+                  }
+                  onDeletePurchase={setDeletingPurchase}
+                />
+              );
+            })}
           </div>
         )}
       </div>
@@ -286,6 +408,72 @@ export function BnplManager() {
             >
               Cancel
             </AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <BnplPurchaseFormDialog
+        open={purchaseTarget !== null}
+        onOpenChange={(open) => !open && setPurchaseTarget(null)}
+        accountName={purchaseTarget?.account.name ?? ""}
+        initialValues={
+          purchaseTarget?.purchase?.type === "recurring"
+            ? {
+                title: purchaseTarget.purchase.title,
+                amount: purchaseTarget.purchase.amount ?? 0,
+                tenureMonths: purchaseTarget.purchase.recurrence.count ?? 1,
+                firstDueMonth: purchaseTarget.purchase.recurrence.dtstart,
+              }
+            : undefined
+        }
+        onSubmit={(values: PurchaseFormValues) => {
+          if (!purchaseTarget) return;
+          if (purchaseTarget.purchase) {
+            updatePurchaseMut.mutate({
+              id: purchaseTarget.purchase._id,
+              data: values,
+            });
+          } else {
+            createPurchaseMut.mutate({
+              accountId: purchaseTarget.account._id,
+              ...values,
+            });
+          }
+        }}
+        isPending={createPurchaseMut.isPending || updatePurchaseMut.isPending}
+      />
+
+      <AlertDialog
+        open={deletingPurchase !== null}
+        onOpenChange={(open) => !open && setDeletingPurchase(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {deletingPurchase?.title}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the purchase and its payment history. This cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletePurchaseMut.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (deletingPurchase)
+                  deletePurchaseMut.mutate({ id: deletingPurchase._id });
+              }}
+              disabled={deletePurchaseMut.isPending}
+            >
+              {deletePurchaseMut.isPending && (
+                <Loader2 className="mr-1 size-4 animate-spin" />
+              )}
+              Delete
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/bnplPurchaseFormDialog.tsx
+++ b/src/components/bnplPurchaseFormDialog.tsx
@@ -5,7 +5,12 @@ import { Loader2 } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { formatUtcDate } from "~/lib/date-utils";
+import {
+  dateInputToUtcDateOnly,
+  formatUtcDate,
+  localDateToUtcDateOnly,
+  startOfUtcMonth,
+} from "~/lib/date-utils";
 import { Button } from "./ui/button";
 import {
   Dialog,
@@ -35,11 +40,14 @@ const PurchaseFormSchema = z.object({
 
 export type PurchaseFormValues = z.infer<typeof PurchaseFormSchema>;
 
-/** `"yyyy-MM"` → UTC midnight on the 1st, or undefined when cleared/invalid. */
+/**
+ * `"yyyy-MM"` → UTC midnight on the 1st, or undefined when cleared/invalid.
+ * Defers to the shared date-input parser so any hardening applied there (a
+ * browser parsing quirk, a range check) reaches this field too.
+ */
 function monthInputToUtc(value: string): Date | undefined {
   if (!value) return undefined;
-  const parsed = new Date(`${value}-01`);
-  return isNaN(parsed.getTime()) ? undefined : parsed;
+  return dateInputToUtcDateOnly(`${value}-01`);
 }
 
 // Shared by useForm's initial state and the create-mode reset below, so the
@@ -49,9 +57,11 @@ function defaultPurchaseFormValues(): PurchaseFormValues {
     title: "",
     amount: 0,
     tenureMonths: 6,
-    firstDueMonth: new Date(
-      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
-    ),
+    // The user's *local* calendar month, mapped into the canonical UTC frame.
+    // Reading `getUTCMonth()` off a bare `new Date()` instead would default to
+    // the previous month for the first 8 hours of every month in UTC+8 (the
+    // app's own PHP locale), anchoring the schedule a month in the past.
+    firstDueMonth: startOfUtcMonth(localDateToUtcDateOnly(new Date())),
   };
 }
 

--- a/src/components/bnplPurchaseFormDialog.tsx
+++ b/src/components/bnplPurchaseFormDialog.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { formatUtcDate } from "~/lib/date-utils";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./ui/form";
+import { Input } from "./ui/input";
+
+const PurchaseFormSchema = z.object({
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  amount: z.coerce.number<number>().min(1, { message: "Amount is required" }),
+  tenureMonths: z.coerce.number<number>().int().min(1).max(60),
+  firstDueMonth: z.date(),
+});
+
+export type PurchaseFormValues = z.infer<typeof PurchaseFormSchema>;
+
+/** `"yyyy-MM"` → UTC midnight on the 1st, or undefined when cleared/invalid. */
+function monthInputToUtc(value: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(`${value}-01`);
+  return isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export function BnplPurchaseFormDialog({
+  open,
+  onOpenChange,
+  accountName,
+  initialValues,
+  onSubmit,
+  isPending,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountName: string;
+  initialValues?: PurchaseFormValues;
+  onSubmit: (values: PurchaseFormValues) => void;
+  isPending: boolean;
+}) {
+  const form = useForm<PurchaseFormValues>({
+    resolver: zodResolver(PurchaseFormSchema),
+    defaultValues: {
+      title: "",
+      amount: 0,
+      tenureMonths: 6,
+      firstDueMonth: new Date(
+        Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
+      ),
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (initialValues) form.reset(initialValues);
+  }, [open, initialValues, form]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {initialValues ? "Edit purchase" : "New purchase"}
+          </DialogTitle>
+          <DialogDescription>
+            Billed on {accountName}&apos;s monthly statement.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+            id="bnpl-purchase-form"
+          >
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Item</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Airpods" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Monthly installment</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} step="0.01" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tenureMonths"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Months</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} max={60} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="firstDueMonth"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First statement month</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="month"
+                      value={
+                        field.value ? formatUtcDate(field.value, "yyyy-MM") : ""
+                      }
+                      onChange={(e) =>
+                        field.onChange(monthInputToUtc(e.target.value))
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The day comes from the account&apos;s due day.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="bnpl-purchase-form" disabled={isPending}>
+            {isPending && <Loader2 className="mr-1 size-4 animate-spin" />}
+            {initialValues ? "Save" : "Add"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bnplPurchaseFormDialog.tsx
+++ b/src/components/bnplPurchaseFormDialog.tsx
@@ -42,6 +42,19 @@ function monthInputToUtc(value: string): Date | undefined {
   return isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
+// Shared by useForm's initial state and the create-mode reset below, so the
+// two can't drift apart into two different "empty purchase" shapes.
+function defaultPurchaseFormValues(): PurchaseFormValues {
+  return {
+    title: "",
+    amount: 0,
+    tenureMonths: 6,
+    firstDueMonth: new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
+    ),
+  };
+}
+
 export function BnplPurchaseFormDialog({
   open,
   onOpenChange,
@@ -59,19 +72,15 @@ export function BnplPurchaseFormDialog({
 }) {
   const form = useForm<PurchaseFormValues>({
     resolver: zodResolver(PurchaseFormSchema),
-    defaultValues: {
-      title: "",
-      amount: 0,
-      tenureMonths: 6,
-      firstDueMonth: new Date(
-        Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1),
-      ),
-    },
+    defaultValues: defaultPurchaseFormValues(),
   });
 
+  // Reset on open so an edit shows the current values and a create starts
+  // clean — otherwise one dialog instance serving both modes leaves a create
+  // holding whatever an earlier edit last had in it.
   useEffect(() => {
     if (!open) return;
-    if (initialValues) form.reset(initialValues);
+    form.reset(initialValues ?? defaultPurchaseFormValues());
   }, [open, initialValues, form]);
 
   return (

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -17,7 +17,11 @@ import {
   createPayRule,
   partitionBills,
 } from "~/lib/bill-utils";
-import { groupStatements } from "~/lib/bnpl-utils";
+import {
+  groupStatements,
+  isStatementPaid,
+  statementRemaining,
+} from "~/lib/bnpl-utils";
 import {
   formatUtcDate,
   localDateToUtcDateOnly,
@@ -73,15 +77,15 @@ export function FinancialSummaryCards({
     const { bills: ordinaryRows, installments } = partitionBills(periodRows);
     const statements = groupStatements(installments, accounts ?? []);
 
-    // Remaining counts every unpaid peso, installments included — a statement
-    // is unpaid until all of its purchases are.
+    // Remaining counts every unpaid peso, installments included. A statement
+    // contributes only its *unpaid* purchases, not its whole amount — a
+    // statement settled at ₱3,000 that then gains a ₱500 purchase owes ₱500,
+    // and charging the full ₱3,500 would re-bill money already marked paid.
     const remainingBills = sumBy(ordinaryRows, (b) =>
       isOccurrencePaid(paidKeys, b._id, b.date) ? 0 : (b.amount ?? 0),
     );
     const remainingStatements = sumBy(statements, (s) =>
-      s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date))
-        ? 0
-        : s.amount,
+      statementRemaining(paidKeys, s),
     );
 
     // Nearest upcoming unpaid obligation of either kind.
@@ -93,8 +97,7 @@ export function FinancialSummaryCards({
     );
     const upcomingStatement = statements.find(
       (s) =>
-        utcDateOnlyToLocal(s.date) >= today &&
-        !s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date)),
+        utcDateOnlyToLocal(s.date) >= today && !isStatementPaid(paidKeys, s),
     );
 
     const candidates: Array<{ title: string; date: Date }> = [];

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -12,7 +12,12 @@ import { startOfDay } from "date-fns";
 import { sumBy } from "lodash";
 import { Card, CardContent } from "~/components/ui/card";
 import { cn } from "~/lib/utils";
-import { createPayRule, computeBillsInPeriod } from "~/lib/bill-utils";
+import {
+  computeBillsInPeriod,
+  createPayRule,
+  partitionBills,
+} from "~/lib/bill-utils";
+import { groupStatements } from "~/lib/bnpl-utils";
 import {
   formatUtcDate,
   localDateToUtcDateOnly,
@@ -54,36 +59,68 @@ export function FinancialSummaryCards({
 }) {
   const { data: payments } = api.payment.getAll.useQuery();
   const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
+  const { data: accounts } = api.bnpl.getAll.useQuery();
 
-  const { remaining, nextBill } = useMemo(() => {
+  const { remaining, nextItem, billCount } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
     const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
-    if (!currentPay) return { remaining: 0, nextBill: null };
+    if (!currentPay) return { remaining: 0, nextItem: null, billCount: 0 };
 
     const nextPayDate = payRule.after(currentPay);
-    if (!nextPayDate) return { remaining: 0, nextBill: null };
+    if (!nextPayDate) return { remaining: 0, nextItem: null, billCount: 0 };
 
-    const periodBills = computeBillsInPeriod(bills, currentPay, nextPayDate);
+    const periodRows = computeBillsInPeriod(bills, currentPay, nextPayDate);
+    const { bills: ordinaryRows, installments } = partitionBills(periodRows);
+    const statements = groupStatements(installments, accounts ?? []);
 
-    // What's still owed this period — paid occurrences contribute 0. A plain
-    // remaining-to-pay total (no income term), so it stays coherent and shrinks
-    // toward ₱0 as bills are marked paid, whatever the income is.
-    const remaining = sumBy(periodBills, (b) =>
+    // Remaining counts every unpaid peso, installments included — a statement
+    // is unpaid until all of its purchases are.
+    const remainingBills = sumBy(ordinaryRows, (b) =>
       isOccurrencePaid(paidKeys, b._id, b.date) ? 0 : (b.amount ?? 0),
     );
+    const remainingStatements = sumBy(statements, (s) =>
+      s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date))
+        ? 0
+        : s.amount,
+    );
 
-    // Nearest upcoming *unpaid* bill (today or future). Day-granularity compare:
-    // bill dates are at midnight, so `b.date >= new Date()` would drop a bill due
-    // today once the wall clock passes midnight.
+    // "Total Bills" counts a statement as one obligation, not N purchases —
+    // one payment is what the user actually makes.
+    const { bills: ordinaryAll, installments: installmentsAll } =
+      partitionBills(bills);
+    const accountsWithPurchases = new Set(
+      installmentsAll.map((b) => b.bnplAccountId),
+    );
+
+    // Nearest upcoming unpaid obligation of either kind.
     const today = startOfDay(new Date());
-    const upcoming = periodBills.find(
+    const upcomingBill = ordinaryRows.find(
       (b) =>
         utcDateOnlyToLocal(b.date) >= today &&
         !isOccurrencePaid(paidKeys, b._id, b.date),
     );
+    const upcomingStatement = statements.find(
+      (s) =>
+        utcDateOnlyToLocal(s.date) >= today &&
+        !s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date)),
+    );
 
-    return { remaining, nextBill: upcoming ?? null };
-  }, [incomeProfile, bills, paidKeys]);
+    const candidates: Array<{ title: string; date: Date }> = [];
+    if (upcomingBill)
+      candidates.push({ title: upcomingBill.title, date: upcomingBill.date });
+    if (upcomingStatement)
+      candidates.push({
+        title: upcomingStatement.accountName,
+        date: upcomingStatement.date,
+      });
+    candidates.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    return {
+      remaining: remainingBills + remainingStatements,
+      nextItem: candidates[0] ?? null,
+      billCount: ordinaryAll.length + accountsWithPurchases.size,
+    };
+  }, [incomeProfile, bills, paidKeys, accounts]);
 
   const income = incomeProfile.amount ?? 0;
 
@@ -98,7 +135,7 @@ export function FinancialSummaryCards({
     {
       icon: FileText,
       label: "Total Bills",
-      value: bills.length.toString(),
+      value: billCount.toString(),
       subtitle: "Active bills",
       mono: true,
     },
@@ -113,8 +150,10 @@ export function FinancialSummaryCards({
     {
       icon: CalendarClock,
       label: "Next Bill",
-      value: nextBill?.title ?? "None",
-      subtitle: nextBill ? formatUtcDate(nextBill.date, "MMM dd, yyyy") : "No upcoming bills",
+      value: nextItem?.title ?? "None",
+      subtitle: nextItem
+        ? formatUtcDate(nextItem.date, "MMM dd, yyyy")
+        : "No upcoming bills",
       mono: false,
     },
   ];

--- a/src/components/financialSummaryCards.tsx
+++ b/src/components/financialSummaryCards.tsx
@@ -61,13 +61,13 @@ export function FinancialSummaryCards({
   const paidKeys = useMemo(() => buildPaidLookup(payments ?? []), [payments]);
   const { data: accounts } = api.bnpl.getAll.useQuery();
 
-  const { remaining, nextItem, billCount } = useMemo(() => {
+  const { remaining, nextItem } = useMemo(() => {
     const payRule = createPayRule(incomeProfile);
     const currentPay = payRule.before(localDateToUtcDateOnly(new Date()), true);
-    if (!currentPay) return { remaining: 0, nextItem: null, billCount: 0 };
+    if (!currentPay) return { remaining: 0, nextItem: null };
 
     const nextPayDate = payRule.after(currentPay);
-    if (!nextPayDate) return { remaining: 0, nextItem: null, billCount: 0 };
+    if (!nextPayDate) return { remaining: 0, nextItem: null };
 
     const periodRows = computeBillsInPeriod(bills, currentPay, nextPayDate);
     const { bills: ordinaryRows, installments } = partitionBills(periodRows);
@@ -82,14 +82,6 @@ export function FinancialSummaryCards({
       s.billIds.every((id) => isOccurrencePaid(paidKeys, id, s.date))
         ? 0
         : s.amount,
-    );
-
-    // "Total Bills" counts a statement as one obligation, not N purchases —
-    // one payment is what the user actually makes.
-    const { bills: ordinaryAll, installments: installmentsAll } =
-      partitionBills(bills);
-    const accountsWithPurchases = new Set(
-      installmentsAll.map((b) => b.bnplAccountId),
     );
 
     // Nearest upcoming unpaid obligation of either kind.
@@ -118,9 +110,21 @@ export function FinancialSummaryCards({
     return {
       remaining: remainingBills + remainingStatements,
       nextItem: candidates[0] ?? null,
-      billCount: ordinaryAll.length + accountsWithPurchases.size,
     };
   }, [incomeProfile, bills, paidKeys, accounts]);
+
+  // Counted independently of the pay period. A statement is one obligation
+  // whenever it falls, and this card has always been whole-list ("Active
+  // bills"). Deriving it inside the period memo would make it read 0 whenever
+  // no current pay period resolves — e.g. a profile whose start date is still
+  // in the future.
+  const billCount = useMemo(() => {
+    const { bills: ordinaryAll, installments } = partitionBills(bills);
+    const accountsWithPurchases = new Set(
+      installments.map((b) => b.bnplAccountId),
+    );
+    return ordinaryAll.length + accountsWithPurchases.size;
+  }, [bills]);
 
   const income = incomeProfile.amount ?? 0;
 

--- a/src/components/playgroundStartScreen.tsx
+++ b/src/components/playgroundStartScreen.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { partitionBills } from "~/lib/bill-utils";
 import { api } from "~/trpc/react";
 import { usePlaygroundDispatch } from "./playgroundContext";
 import type { IncomeProfile } from "~/types";
@@ -28,7 +29,8 @@ export function PlaygroundStartScreen({
   };
 
   const handleCloneBills = () => {
-    dispatch({ type: "INIT_CLONE", incomeProfile, bills: bills ?? [] });
+    const { bills: ordinaryBills } = partitionBills(bills ?? []);
+    dispatch({ type: "INIT_CLONE", incomeProfile, bills: ordinaryBills });
   };
 
   return (

--- a/src/lib/bill-utils.test.ts
+++ b/src/lib/bill-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { partitionBills } from "~/lib/bill-utils";
+
+describe("partitionBills", () => {
+  it("splits installments from ordinary bills", () => {
+    const rows = [
+      { _id: "a" },
+      { _id: "b", bnplAccountId: "acc1" },
+      { _id: "c", bnplAccountId: null },
+      { _id: "d", bnplAccountId: "acc2" },
+    ];
+
+    const { bills, installments } = partitionBills(rows);
+
+    expect(bills.map((b) => b._id)).toEqual(["a", "c"]);
+    expect(installments.map((b) => b._id)).toEqual(["b", "d"]);
+  });
+
+  it("treats an empty-string account id as an ordinary bill", () => {
+    // Defensive: an empty string is not a usable ObjectId, so it must not be
+    // routed into the installment bucket where it would be grouped by a
+    // meaningless key.
+    const { bills, installments } = partitionBills([
+      { _id: "a", bnplAccountId: "" },
+    ]);
+
+    expect(bills.map((b) => b._id)).toEqual(["a"]);
+    expect(installments).toEqual([]);
+  });
+
+  it("preserves input order within each bucket", () => {
+    const rows = [
+      { _id: "1", bnplAccountId: "x" },
+      { _id: "2" },
+      { _id: "3", bnplAccountId: "x" },
+      { _id: "4" },
+    ];
+
+    const { bills, installments } = partitionBills(rows);
+
+    expect(bills.map((b) => b._id)).toEqual(["2", "4"]);
+    expect(installments.map((b) => b._id)).toEqual(["1", "3"]);
+  });
+
+  it("returns two empty buckets for empty input", () => {
+    expect(partitionBills([])).toEqual({ bills: [], installments: [] });
+  });
+});

--- a/src/lib/bill-utils.ts
+++ b/src/lib/bill-utils.ts
@@ -1,6 +1,6 @@
 import { addMonths, isAfter, isBefore, isEqual } from "date-fns";
 import { RRule } from "rrule";
-import { localDateToUtcDateOnly } from "./date-utils";
+import { localDateToUtcDateOnly, utcDateInMonth } from "./date-utils";
 import type { BillEvent, IncomeProfile } from "~/types";
 
 export function getFrequency(freq: "weekly" | "fortnightly" | "monthly") {
@@ -53,10 +53,7 @@ function monthlyOccurrencesInPeriod(
     const monthIndex = startMonth + i * step;
     const year = startYear + Math.floor(monthIndex / 12);
     const month = monthIndex % 12;
-    const lastDayOfMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-    const occ = new Date(
-      Date.UTC(year, month, Math.min(targetDay, lastDayOfMonth)),
-    );
+    const occ = utcDateInMonth(year, month, targetDay);
 
     if (until != null && isAfter(occ, until)) break;
     emitted++;

--- a/src/lib/bill-utils.ts
+++ b/src/lib/bill-utils.ts
@@ -1,6 +1,10 @@
 import { addMonths, isAfter, isBefore, isEqual } from "date-fns";
 import { RRule } from "rrule";
-import { localDateToUtcDateOnly, utcDateInMonth } from "./date-utils";
+import {
+  addUtcMonths,
+  localDateToUtcDateOnly,
+  utcDateInMonth,
+} from "./date-utils";
 import type { BillEvent, IncomeProfile } from "~/types";
 
 export function getFrequency(freq: "weekly" | "fortnightly" | "monthly") {
@@ -39,8 +43,6 @@ function monthlyOccurrencesInPeriod(
   periodEnd: Date,
 ) {
   const targetDay = dtstart.getUTCDate();
-  const startYear = dtstart.getUTCFullYear();
-  const startMonth = dtstart.getUTCMonth();
   const step = Math.max(1, interval);
 
   const occurrences: Date[] = [];
@@ -50,10 +52,7 @@ function monthlyOccurrencesInPeriod(
   for (let i = 0; i < 12_000; i++) {
     if (count != null && emitted >= count) break;
 
-    const monthIndex = startMonth + i * step;
-    const year = startYear + Math.floor(monthIndex / 12);
-    const month = monthIndex % 12;
-    const occ = utcDateInMonth(year, month, targetDay);
+    const occ = utcDateInMonth(addUtcMonths(dtstart, i * step), targetDay);
 
     if (until != null && isAfter(occ, until)) break;
     emitted++;

--- a/src/lib/bill-utils.ts
+++ b/src/lib/bill-utils.ts
@@ -188,3 +188,33 @@ export function getPayPeriodsByCount(
     };
   });
 }
+
+/**
+ * Split rows into ordinary bills and BNPL installments.
+ *
+ * BNPL purchases share the `bills` collection, so `bill.getAll` returns both
+ * kinds. This is the single place that filter is spelled: a polymorphic
+ * collection rots when each call site writes its own predicate, and a missed
+ * one leaks installments back into a list as individual rows — the exact
+ * clutter the BNPL feature removes.
+ *
+ * Generic over the element type because two shapes need it: raw `BillEvent`s
+ * (the summary cards) and generated occurrence rows (`BillEvent & { date: Date }`,
+ * the bill list).
+ */
+export function partitionBills<T extends { bnplAccountId?: string | null }>(
+  rows: T[],
+): { bills: T[]; installments: T[] } {
+  const bills: T[] = [];
+  const installments: T[] = [];
+
+  for (const row of rows) {
+    if (row.bnplAccountId) {
+      installments.push(row);
+    } else {
+      bills.push(row);
+    }
+  }
+
+  return { bills, installments };
+}

--- a/src/lib/bnpl-utils.test.ts
+++ b/src/lib/bnpl-utils.test.ts
@@ -1,27 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { deriveStatementDtstart, groupStatements, installmentProgress } from "~/lib/bnpl-utils";
+import {
+  deriveStatementDtstart,
+  groupStatements,
+  installmentProgress,
+  isStatementPaid,
+  statementBillIds,
+  statementRemaining,
+} from "~/lib/bnpl-utils";
+import { occurrenceKey } from "~/lib/payment-utils";
 import type { BnplAccount } from "~/types";
 
 // Helper: a UTC-midnight date, for readable expectations.
-const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d));
+const utc = (y: number, m: number, d: number) =>
+  new Date(Date.UTC(y, m - 1, d));
 
 describe("deriveStatementDtstart", () => {
   it("uses the account's due day in the chosen month", () => {
-    expect(deriveStatementDtstart(15, utc(2026, 9, 1))).toEqual(utc(2026, 9, 15));
+    expect(deriveStatementDtstart(15, utc(2026, 9, 1))).toEqual(
+      utc(2026, 9, 15),
+    );
   });
 
   it("ignores the day component of firstDueMonth", () => {
     // Only the year and month of the input matter; the day comes from dueDay.
-    expect(deriveStatementDtstart(5, utc(2026, 9, 28))).toEqual(utc(2026, 9, 5));
+    expect(deriveStatementDtstart(5, utc(2026, 9, 28))).toEqual(
+      utc(2026, 9, 5),
+    );
   });
 
   it("clamps day 31 back to the end of a short month", () => {
-    expect(deriveStatementDtstart(31, utc(2026, 2, 1))).toEqual(utc(2026, 2, 28));
-    expect(deriveStatementDtstart(31, utc(2026, 4, 1))).toEqual(utc(2026, 4, 30));
+    expect(deriveStatementDtstart(31, utc(2026, 2, 1))).toEqual(
+      utc(2026, 2, 28),
+    );
+    expect(deriveStatementDtstart(31, utc(2026, 4, 1))).toEqual(
+      utc(2026, 4, 30),
+    );
   });
 
   it("clamps to Feb 29 in a leap year", () => {
-    expect(deriveStatementDtstart(31, utc(2028, 2, 1))).toEqual(utc(2028, 2, 29));
+    expect(deriveStatementDtstart(31, utc(2028, 2, 1))).toEqual(
+      utc(2028, 2, 29),
+    );
   });
 
   it("leaves day 28 untouched in every month", () => {
@@ -50,9 +69,19 @@ describe("groupStatements", () => {
   it("sums one account's installments on the same date into one statement", () => {
     const result = groupStatements(
       [
-        { _id: "b1", bnplAccountId: "a1", amount: 1250, date: utc(2026, 9, 15) },
+        {
+          _id: "b1",
+          bnplAccountId: "a1",
+          amount: 1250,
+          date: utc(2026, 9, 15),
+        },
         { _id: "b2", bnplAccountId: "a1", amount: 700, date: utc(2026, 9, 15) },
-        { _id: "b3", bnplAccountId: "a1", amount: 2250, date: utc(2026, 9, 15) },
+        {
+          _id: "b3",
+          bnplAccountId: "a1",
+          amount: 2250,
+          date: utc(2026, 9, 15),
+        },
       ],
       [account("a1", "SPayLater")],
     );
@@ -62,15 +91,23 @@ describe("groupStatements", () => {
       accountId: "a1",
       accountName: "SPayLater",
       amount: 4200,
-      purchaseCount: 3,
     });
-    expect(result[0]?.billIds).toEqual(["b1", "b2", "b3"]);
+    expect(result[0] && statementBillIds(result[0])).toEqual([
+      "b1",
+      "b2",
+      "b3",
+    ]);
   });
 
   it("keeps different accounts as separate statements", () => {
     const result = groupStatements(
       [
-        { _id: "b1", bnplAccountId: "a1", amount: 1000, date: utc(2026, 9, 15) },
+        {
+          _id: "b1",
+          bnplAccountId: "a1",
+          amount: 1000,
+          date: utc(2026, 9, 15),
+        },
         { _id: "b2", bnplAccountId: "a2", amount: 900, date: utc(2026, 9, 20) },
       ],
       [account("a1", "SPayLater"), account("a2", "LazPayLater", 20)],
@@ -90,7 +127,11 @@ describe("groupStatements", () => {
         { _id: "b2", bnplAccountId: "a1", amount: 1, date: utc(2026, 9, 15) },
         { _id: "b3", bnplAccountId: "a3", amount: 1, date: utc(2026, 9, 15) },
       ],
-      [account("a1", "Bravo"), account("a2", "Alpha", 20), account("a3", "Alpha")],
+      [
+        account("a1", "Bravo"),
+        account("a2", "Alpha", 20),
+        account("a3", "Alpha"),
+      ],
     );
 
     expect(result.map((s) => [s.accountName, s.date.getUTCDate()])).toEqual([
@@ -107,7 +148,7 @@ describe("groupStatements", () => {
     );
 
     expect(result[0]?.amount).toBe(0);
-    expect(result[0]?.purchaseCount).toBe(1);
+    expect(result[0]?.items).toHaveLength(1);
   });
 
   it("keeps installments whose account is unknown, under a fallback name", () => {
@@ -115,7 +156,14 @@ describe("groupStatements", () => {
     // total already includes this installment, so dropping it here would break
     // the "subtotals sum to the balance" invariant the bill list documents.
     const result = groupStatements(
-      [{ _id: "b1", bnplAccountId: "gone", amount: 500, date: utc(2026, 9, 15) }],
+      [
+        {
+          _id: "b1",
+          bnplAccountId: "gone",
+          amount: 500,
+          date: utc(2026, 9, 15),
+        },
+      ],
       [],
     );
 
@@ -144,6 +192,75 @@ describe("groupStatements", () => {
   it("returns nothing for no installments", () => {
     expect(groupStatements([], [account("a1", "SPayLater")])).toEqual([]);
   });
+
+  it("consolidates one account's month even when occurrence days disagree", () => {
+    // Regression: `deriveStatementDtstart` clamps, and the occurrence generator
+    // re-derives its day from the clamped anchor — so a purchase first billed in
+    // February fires on the 28th while a sibling first billed in March fires on
+    // the 31st. Grouping by occurrence date emitted TWO statements a month for
+    // one provider, the exact split this module exists to prevent.
+    const result = groupStatements(
+      [
+        {
+          _id: "feb-anchored",
+          bnplAccountId: "a1",
+          amount: 50,
+          date: utc(2026, 3, 28),
+        },
+        {
+          _id: "mar-anchored",
+          bnplAccountId: "a1",
+          amount: 100,
+          date: utc(2026, 3, 31),
+        },
+      ],
+      [account("a1", "SPayLater", 31)],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ amount: 150, date: utc(2026, 3, 31) });
+    expect(result[0] && statementBillIds(result[0])).toEqual([
+      "feb-anchored",
+      "mar-anchored",
+    ]);
+  });
+
+  it("dates a statement from the account's due day, not the occurrence", () => {
+    // dueDay 31 in a 30-day month clamps to the 30th for every purchase on it.
+    const result = groupStatements(
+      [{ _id: "b1", bnplAccountId: "a1", amount: 10, date: utc(2026, 4, 28) }],
+      [account("a1", "SPayLater", 31)],
+    );
+
+    expect(result[0]?.date).toEqual(utc(2026, 4, 30));
+  });
+});
+
+describe("statement paid state", () => {
+  const statement = groupStatements(
+    [
+      { _id: "b1", bnplAccountId: "a1", amount: 1000, date: utc(2026, 9, 15) },
+      { _id: "b2", bnplAccountId: "a1", amount: 500, date: utc(2026, 9, 15) },
+    ],
+    [account("a1", "SPayLater")],
+  )[0]!;
+
+  const keysFor = (...billIds: string[]) =>
+    new Set(billIds.map((id) => occurrenceKey(id, statement.date)));
+
+  it("is unpaid until every purchase is settled", () => {
+    expect(isStatementPaid(keysFor(), statement)).toBe(false);
+    expect(isStatementPaid(keysFor("b1"), statement)).toBe(false);
+    expect(isStatementPaid(keysFor("b1", "b2"), statement)).toBe(true);
+  });
+
+  it("charges only the unpaid purchases when partially settled", () => {
+    // The whole point: a settled ₱1,000 purchase must not be re-counted as owed
+    // just because a ₱500 sibling landed on the same statement afterwards.
+    expect(statementRemaining(keysFor(), statement)).toBe(1500);
+    expect(statementRemaining(keysFor("b1"), statement)).toBe(500);
+    expect(statementRemaining(keysFor("b1", "b2"), statement)).toBe(0);
+  });
 });
 
 describe("installmentProgress", () => {
@@ -155,17 +272,21 @@ describe("installmentProgress", () => {
   });
 
   it("counts elapsed months inclusively", () => {
-    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 11, 15))).toEqual({
-      elapsed: 3,
-      total: 6,
-    });
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 11, 15))).toEqual(
+      {
+        elapsed: 3,
+        total: 6,
+      },
+    );
   });
 
   it("counts across a year boundary", () => {
-    expect(installmentProgress(utc(2026, 11, 15), 6, utc(2027, 2, 15))).toEqual({
-      elapsed: 4,
-      total: 6,
-    });
+    expect(installmentProgress(utc(2026, 11, 15), 6, utc(2027, 2, 15))).toEqual(
+      {
+        elapsed: 4,
+        total: 6,
+      },
+    );
   });
 
   it("never exceeds the total", () => {
@@ -185,7 +306,8 @@ describe("installmentProgress", () => {
   it("treats a missing count as a single installment", () => {
     // A purchase always has a tenure, but `count` is optional on the shared
     // recurrence type, so the fallback must be defined rather than NaN.
-    expect(installmentProgress(utc(2026, 9, 15), undefined, utc(2026, 9, 15)))
-      .toEqual({ elapsed: 1, total: 1 });
+    expect(
+      installmentProgress(utc(2026, 9, 15), undefined, utc(2026, 9, 15)),
+    ).toEqual({ elapsed: 1, total: 1 });
   });
 });

--- a/src/lib/bnpl-utils.test.ts
+++ b/src/lib/bnpl-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { deriveStatementDtstart } from "~/lib/bnpl-utils";
+
+// Helper: a UTC-midnight date, for readable expectations.
+const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d));
+
+describe("deriveStatementDtstart", () => {
+  it("uses the account's due day in the chosen month", () => {
+    expect(deriveStatementDtstart(15, utc(2026, 9, 1))).toEqual(utc(2026, 9, 15));
+  });
+
+  it("ignores the day component of firstDueMonth", () => {
+    // Only the year and month of the input matter; the day comes from dueDay.
+    expect(deriveStatementDtstart(5, utc(2026, 9, 28))).toEqual(utc(2026, 9, 5));
+  });
+
+  it("clamps day 31 back to the end of a short month", () => {
+    expect(deriveStatementDtstart(31, utc(2026, 2, 1))).toEqual(utc(2026, 2, 28));
+    expect(deriveStatementDtstart(31, utc(2026, 4, 1))).toEqual(utc(2026, 4, 30));
+  });
+
+  it("clamps to Feb 29 in a leap year", () => {
+    expect(deriveStatementDtstart(31, utc(2028, 2, 1))).toEqual(utc(2028, 2, 29));
+  });
+
+  it("leaves day 28 untouched in every month", () => {
+    for (let month = 1; month <= 12; month++) {
+      expect(deriveStatementDtstart(28, utc(2026, month, 1))).toEqual(
+        utc(2026, month, 28),
+      );
+    }
+  });
+
+  it("returns exact UTC midnight", () => {
+    const result = deriveStatementDtstart(15, utc(2026, 9, 1));
+    expect(result.getUTCHours()).toBe(0);
+    expect(result.getTime() % 86_400_000).toBe(0);
+  });
+});

--- a/src/lib/bnpl-utils.test.ts
+++ b/src/lib/bnpl-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { deriveStatementDtstart } from "~/lib/bnpl-utils";
+import { deriveStatementDtstart, groupStatements, installmentProgress } from "~/lib/bnpl-utils";
+import type { BnplAccount } from "~/types";
 
 // Helper: a UTC-midnight date, for readable expectations.
 const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d));
@@ -35,5 +36,156 @@ describe("deriveStatementDtstart", () => {
     const result = deriveStatementDtstart(15, utc(2026, 9, 1));
     expect(result.getUTCHours()).toBe(0);
     expect(result.getTime() % 86_400_000).toBe(0);
+  });
+});
+
+const account = (id: string, name: string, dueDay = 15): BnplAccount => ({
+  _id: id,
+  userId: "u1",
+  name,
+  dueDay,
+});
+
+describe("groupStatements", () => {
+  it("sums one account's installments on the same date into one statement", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 1250, date: utc(2026, 9, 15) },
+        { _id: "b2", bnplAccountId: "a1", amount: 700, date: utc(2026, 9, 15) },
+        { _id: "b3", bnplAccountId: "a1", amount: 2250, date: utc(2026, 9, 15) },
+      ],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      accountId: "a1",
+      accountName: "SPayLater",
+      amount: 4200,
+      purchaseCount: 3,
+    });
+    expect(result[0]?.billIds).toEqual(["b1", "b2", "b3"]);
+  });
+
+  it("keeps different accounts as separate statements", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 1000, date: utc(2026, 9, 15) },
+        { _id: "b2", bnplAccountId: "a2", amount: 900, date: utc(2026, 9, 20) },
+      ],
+      [account("a1", "SPayLater"), account("a2", "LazPayLater", 20)],
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.accountName)).toEqual([
+      "SPayLater",
+      "LazPayLater",
+    ]);
+  });
+
+  it("sorts by date, then by account name", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a2", amount: 1, date: utc(2026, 9, 20) },
+        { _id: "b2", bnplAccountId: "a1", amount: 1, date: utc(2026, 9, 15) },
+        { _id: "b3", bnplAccountId: "a3", amount: 1, date: utc(2026, 9, 15) },
+      ],
+      [account("a1", "Bravo"), account("a2", "Alpha", 20), account("a3", "Alpha")],
+    );
+
+    expect(result.map((s) => [s.accountName, s.date.getUTCDate()])).toEqual([
+      ["Alpha", 15],
+      ["Bravo", 15],
+      ["Alpha", 20],
+    ]);
+  });
+
+  it("treats a missing amount as zero", () => {
+    const result = groupStatements(
+      [{ _id: "b1", bnplAccountId: "a1", date: utc(2026, 9, 15) }],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result[0]?.amount).toBe(0);
+    expect(result[0]?.purchaseCount).toBe(1);
+  });
+
+  it("keeps installments whose account is unknown, under a fallback name", () => {
+    // Money must never silently vanish from the roll-up: the period's outgoing
+    // total already includes this installment, so dropping it here would break
+    // the "subtotals sum to the balance" invariant the bill list documents.
+    const result = groupStatements(
+      [{ _id: "b1", bnplAccountId: "gone", amount: 500, date: utc(2026, 9, 15) }],
+      [],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ accountName: "BNPL", amount: 500 });
+  });
+
+  it("floors dates to their UTC day when grouping", () => {
+    const result = groupStatements(
+      [
+        { _id: "b1", bnplAccountId: "a1", amount: 100, date: utc(2026, 9, 15) },
+        {
+          _id: "b2",
+          bnplAccountId: "a1",
+          amount: 100,
+          date: new Date(Date.UTC(2026, 8, 15, 13, 30)),
+        },
+      ],
+      [account("a1", "SPayLater")],
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.amount).toBe(200);
+  });
+
+  it("returns nothing for no installments", () => {
+    expect(groupStatements([], [account("a1", "SPayLater")])).toEqual([]);
+  });
+});
+
+describe("installmentProgress", () => {
+  it("counts the first month as installment 1", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 9, 15))).toEqual({
+      elapsed: 1,
+      total: 6,
+    });
+  });
+
+  it("counts elapsed months inclusively", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 11, 15))).toEqual({
+      elapsed: 3,
+      total: 6,
+    });
+  });
+
+  it("counts across a year boundary", () => {
+    expect(installmentProgress(utc(2026, 11, 15), 6, utc(2027, 2, 15))).toEqual({
+      elapsed: 4,
+      total: 6,
+    });
+  });
+
+  it("never exceeds the total", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2028, 9, 15))).toEqual({
+      elapsed: 6,
+      total: 6,
+    });
+  });
+
+  it("reports zero before the first installment", () => {
+    expect(installmentProgress(utc(2026, 9, 15), 6, utc(2026, 8, 15))).toEqual({
+      elapsed: 0,
+      total: 6,
+    });
+  });
+
+  it("treats a missing count as a single installment", () => {
+    // A purchase always has a tenure, but `count` is optional on the shared
+    // recurrence type, so the fallback must be defined rather than NaN.
+    expect(installmentProgress(utc(2026, 9, 15), undefined, utc(2026, 9, 15)))
+      .toEqual({ elapsed: 1, total: 1 });
   });
 });

--- a/src/lib/bnpl-utils.ts
+++ b/src/lib/bnpl-utils.ts
@@ -1,3 +1,6 @@
+import { truncateToUtcDateOnly } from "~/lib/date-utils";
+import type { BnplAccount } from "~/types";
+
 // Pure BNPL logic. A BNPL provider consolidates: every active purchase's
 // installment for the month lands on one statement, with one due date and one
 // payment. That invariant is enforced here — the account owns the day-of-month,
@@ -31,4 +34,99 @@ export function deriveStatementDtstart(
   const month = firstDueMonth.getUTCMonth();
   const day = Math.min(dueDay, lastDayOfUtcMonth(year, month));
   return new Date(Date.UTC(year, month, day));
+}
+
+/** Shown when an installment references an account that no longer exists. */
+const UNKNOWN_ACCOUNT_NAME = "BNPL";
+
+/** One account's consolidated obligation on one date. */
+export interface Statement {
+  accountId: string;
+  accountName: string;
+  date: Date;
+  amount: number;
+  purchaseCount: number;
+  billIds: string[];
+}
+
+/** The shape `groupStatements` needs from a generated occurrence row. */
+interface InstallmentOccurrence {
+  _id: string;
+  bnplAccountId?: string | null;
+  amount?: number;
+  date: Date;
+}
+
+/**
+ * Collapse installment occurrences into one statement per (account, date).
+ *
+ * This is what a BNPL provider actually bills: not N separate purchases, but a
+ * single consolidated payment per account per month. The amount is derived
+ * rather than stored, so it shrinks on its own as purchases finish their tenure.
+ *
+ * An installment whose account has vanished is kept under a fallback name
+ * instead of being dropped. The enclosing period's outgoing total already counts
+ * it, so discarding it here would make the section subtotals stop summing to the
+ * balance — the same reasoning behind the bill list's "Ungrouped" catch-all.
+ */
+export function groupStatements(
+  installments: InstallmentOccurrence[],
+  accounts: BnplAccount[],
+): Statement[] {
+  const nameById = new Map(accounts.map((a) => [a._id, a.name]));
+  const byKey = new Map<string, Statement>();
+
+  for (const row of installments) {
+    const accountId = row.bnplAccountId;
+    if (!accountId) continue;
+
+    const date = truncateToUtcDateOnly(row.date);
+    const key = `${accountId}:${date.getTime()}`;
+
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.amount += row.amount ?? 0;
+      existing.purchaseCount += 1;
+      existing.billIds.push(row._id);
+      continue;
+    }
+
+    byKey.set(key, {
+      accountId,
+      accountName: nameById.get(accountId) ?? UNKNOWN_ACCOUNT_NAME,
+      date,
+      amount: row.amount ?? 0,
+      purchaseCount: 1,
+      billIds: [row._id],
+    });
+  }
+
+  return [...byKey.values()].sort(
+    (a, b) =>
+      a.date.getTime() - b.date.getTime() ||
+      a.accountName.localeCompare(b.accountName),
+  );
+}
+
+/**
+ * How far a purchase has advanced through its tenure as of a given statement
+ * date — the "3 of 6" on an account card.
+ *
+ * Counted inclusively from `dtstart`, so the first statement reads 1 of N, and
+ * clamped to `[0, total]` so a long-finished purchase reads N of N rather than
+ * drifting past it. Month arithmetic uses UTC fields to stay in the same frame
+ * as the stored anchor.
+ */
+export function installmentProgress(
+  dtstart: Date,
+  count: number | undefined,
+  asOf: Date,
+): { elapsed: number; total: number } {
+  const total = count ?? 1;
+  const monthsApart =
+    (asOf.getUTCFullYear() - dtstart.getUTCFullYear()) * 12 +
+    (asOf.getUTCMonth() - dtstart.getUTCMonth());
+  const elapsed = Math.min(Math.max(monthsApart + 1, 0), total);
+
+  return { elapsed, total };
 }

--- a/src/lib/bnpl-utils.ts
+++ b/src/lib/bnpl-utils.ts
@@ -1,39 +1,41 @@
-import { truncateToUtcDateOnly } from "~/lib/date-utils";
+import { truncateToUtcDateOnly, utcDateInMonth } from "~/lib/date-utils";
+import { occurrenceKey } from "~/lib/payment-utils";
 import type { BnplAccount } from "~/types";
 
 // Pure BNPL logic. A BNPL provider consolidates: every active purchase's
 // installment for the month lands on one statement, with one due date and one
 // payment. That invariant is enforced here — the account owns the day-of-month,
-// and a purchase's schedule is derived from it rather than supplied alongside
-// it, so a split statement can't be constructed.
-
-/** Last day of the given UTC month (`month` is 0-indexed). */
-function lastDayOfUtcMonth(year: number, month: number): number {
-  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-}
+// and both the statement's date and its membership are derived from it rather
+// than read off each purchase's own occurrence, so a split statement can't be
+// constructed even when a purchase's stored anchor has drifted.
 
 /**
  * First statement date for a purchase: the account's `dueDay` placed in the
  * month of `firstDueMonth`, at canonical UTC midnight.
  *
- * A `dueDay` of 29–31 doesn't exist in every month, so it clamps *backward* to
- * that month's last day — day 31 in February yields Feb 28 (Feb 29 in a leap
- * year). Rolling forward instead would push the statement into the wrong month
- * and skip the intended one. This matches the clamping that
- * `monthlyOccurrencesInPeriod` applies to every occurrence *after* the first;
- * doing it here keeps the anchor in the same frame as the series it seeds.
+ * Uses the same `utcDateInMonth` clamp the monthly occurrence generator applies,
+ * so the anchor sits in exactly the frame of the series it seeds.
  *
  * Only the year and month of `firstDueMonth` are read — its day is irrelevant,
  * since the day always comes from the account.
+ *
+ * NOTE: the clamp is lossy. A `dueDay` of 31 anchored in February stores day 28,
+ * and `monthlyOccurrencesInPeriod` re-derives its `targetDay` from that stored
+ * day — so this purchase's later occurrences fall on the 28th while a sibling
+ * anchored in a 31-day month falls on the 31st. `groupStatements` is what keeps
+ * that drift invisible: it consolidates by *month*, not by occurrence date. The
+ * deeper fix is to store only the first month and derive the day at read time
+ * from `account.dueDay`, which would also remove `bnpl.update`'s fan-out.
  */
 export function deriveStatementDtstart(
   dueDay: number,
   firstDueMonth: Date,
 ): Date {
-  const year = firstDueMonth.getUTCFullYear();
-  const month = firstDueMonth.getUTCMonth();
-  const day = Math.min(dueDay, lastDayOfUtcMonth(year, month));
-  return new Date(Date.UTC(year, month, day));
+  return utcDateInMonth(
+    firstDueMonth.getUTCFullYear(),
+    firstDueMonth.getUTCMonth(),
+    dueDay,
+  );
 }
 
 /** Shown when an installment references an account that no longer exists. */
@@ -45,8 +47,12 @@ export interface Statement {
   accountName: string;
   date: Date;
   amount: number;
-  purchaseCount: number;
-  billIds: string[];
+  /**
+   * Per-purchase breakdown. Keeping the amounts (not just the ids) is what lets
+   * a partially settled statement report only what is still owed — see
+   * `statementRemaining`.
+   */
+  items: Array<{ billId: string; amount: number }>;
 }
 
 /** The shape `groupStatements` needs from a generated occurrence row. */
@@ -58,11 +64,66 @@ interface InstallmentOccurrence {
 }
 
 /**
- * Collapse installment occurrences into one statement per (account, date).
+ * Stable composite key identifying one statement, mirroring `occurrenceKey`'s
+ * role for a single bill occurrence: one spelling, so every producer and
+ * consumer of a statement key agrees. A `:` can't appear in a hex ObjectId, so
+ * account and day never collide.
+ */
+export function statementKey(accountId: string, date: Date): string {
+  return `${accountId}:${truncateToUtcDateOnly(date).getTime()}`;
+}
+
+/** The bill ids a statement consolidates — the unit `payment.markStatement*` acts on. */
+export function statementBillIds(statement: Statement): string[] {
+  return statement.items.map((item) => item.billId);
+}
+
+/**
+ * True when every purchase on the statement is settled. A purchase added after
+ * the statement was paid correctly flips it back to unpaid.
+ */
+export function isStatementPaid(
+  paidKeys: Set<string>,
+  statement: Statement,
+): boolean {
+  return statement.items.every((item) =>
+    paidKeys.has(occurrenceKey(item.billId, statement.date)),
+  );
+}
+
+/**
+ * What is still owed on a statement — the sum of its *unpaid* purchases, not an
+ * all-or-nothing whole-statement figure. A statement settled at ₱3,000 that
+ * then gains a ₱500 purchase owes ₱500, not ₱3,500.
+ */
+export function statementRemaining(
+  paidKeys: Set<string>,
+  statement: Statement,
+): number {
+  return statement.items.reduce(
+    (total, item) =>
+      paidKeys.has(occurrenceKey(item.billId, statement.date))
+        ? total
+        : total + item.amount,
+    0,
+  );
+}
+
+/**
+ * Collapse installment occurrences into one statement per (account, month).
  *
  * This is what a BNPL provider actually bills: not N separate purchases, but a
  * single consolidated payment per account per month. The amount is derived
  * rather than stored, so it shrinks on its own as purchases finish their tenure.
+ *
+ * Grouping is by *calendar month*, and the statement's date is the account's
+ * `dueDay` clamped into that month — deliberately not each occurrence's own
+ * date. Occurrence dates can disagree within one account (see the note on
+ * `deriveStatementDtstart`), and keying on them would emit two statements a
+ * month for one provider, which is the one thing this module exists to prevent.
+ * Dating the statement from the account also means every paid-marker for it is
+ * written on the same day, so `bnpl.update`'s month-preserving marker shift
+ * lands exactly on the new statement date.
  *
  * An installment whose account has vanished is kept under a fallback name
  * instead of being dropped. The enclosing period's outgoing total already counts
@@ -73,31 +134,36 @@ export function groupStatements(
   installments: InstallmentOccurrence[],
   accounts: BnplAccount[],
 ): Statement[] {
-  const nameById = new Map(accounts.map((a) => [a._id, a.name]));
+  const accountById = new Map(accounts.map((a) => [a._id, a]));
   const byKey = new Map<string, Statement>();
 
   for (const row of installments) {
     const accountId = row.bnplAccountId;
     if (!accountId) continue;
 
-    const date = truncateToUtcDateOnly(row.date);
-    const key = `${accountId}:${date.getTime()}`;
+    const occurrence = truncateToUtcDateOnly(row.date);
+    const account = accountById.get(accountId);
+    // With no account there is no dueDay to date the statement from, so the
+    // occurrence's own day stands in.
+    const date = account
+      ? deriveStatementDtstart(account.dueDay, occurrence)
+      : occurrence;
+    const key = statementKey(accountId, date);
+    const item = { billId: row._id, amount: row.amount ?? 0 };
 
     const existing = byKey.get(key);
     if (existing) {
-      existing.amount += row.amount ?? 0;
-      existing.purchaseCount += 1;
-      existing.billIds.push(row._id);
+      existing.amount += item.amount;
+      existing.items.push(item);
       continue;
     }
 
     byKey.set(key, {
       accountId,
-      accountName: nameById.get(accountId) ?? UNKNOWN_ACCOUNT_NAME,
+      accountName: account?.name ?? UNKNOWN_ACCOUNT_NAME,
       date,
-      amount: row.amount ?? 0,
-      purchaseCount: 1,
-      billIds: [row._id],
+      amount: item.amount,
+      items: [item],
     });
   }
 
@@ -109,8 +175,8 @@ export function groupStatements(
 }
 
 /**
- * How far a purchase has advanced through its tenure as of a given statement
- * date — the "3 of 6" on an account card.
+ * How far a purchase has advanced through its tenure as of a given date — the
+ * "3 of 6" on an account card.
  *
  * Counted inclusively from `dtstart`, so the first statement reads 1 of N, and
  * clamped to `[0, total]` so a long-finished purchase reads N of N rather than

--- a/src/lib/bnpl-utils.ts
+++ b/src/lib/bnpl-utils.ts
@@ -1,0 +1,34 @@
+// Pure BNPL logic. A BNPL provider consolidates: every active purchase's
+// installment for the month lands on one statement, with one due date and one
+// payment. That invariant is enforced here — the account owns the day-of-month,
+// and a purchase's schedule is derived from it rather than supplied alongside
+// it, so a split statement can't be constructed.
+
+/** Last day of the given UTC month (`month` is 0-indexed). */
+function lastDayOfUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+/**
+ * First statement date for a purchase: the account's `dueDay` placed in the
+ * month of `firstDueMonth`, at canonical UTC midnight.
+ *
+ * A `dueDay` of 29–31 doesn't exist in every month, so it clamps *backward* to
+ * that month's last day — day 31 in February yields Feb 28 (Feb 29 in a leap
+ * year). Rolling forward instead would push the statement into the wrong month
+ * and skip the intended one. This matches the clamping that
+ * `monthlyOccurrencesInPeriod` applies to every occurrence *after* the first;
+ * doing it here keeps the anchor in the same frame as the series it seeds.
+ *
+ * Only the year and month of `firstDueMonth` are read — its day is irrelevant,
+ * since the day always comes from the account.
+ */
+export function deriveStatementDtstart(
+  dueDay: number,
+  firstDueMonth: Date,
+): Date {
+  const year = firstDueMonth.getUTCFullYear();
+  const month = firstDueMonth.getUTCMonth();
+  const day = Math.min(dueDay, lastDayOfUtcMonth(year, month));
+  return new Date(Date.UTC(year, month, day));
+}

--- a/src/lib/bnpl-utils.ts
+++ b/src/lib/bnpl-utils.ts
@@ -31,11 +31,7 @@ export function deriveStatementDtstart(
   dueDay: number,
   firstDueMonth: Date,
 ): Date {
-  return utcDateInMonth(
-    firstDueMonth.getUTCFullYear(),
-    firstDueMonth.getUTCMonth(),
-    dueDay,
-  );
+  return utcDateInMonth(firstDueMonth, dueDay);
 }
 
 /** Shown when an installment references an account that no longer exists. */

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  addUtcMonths,
+  formatUtcDate,
+  startOfUtcMonth,
+  utcDateInMonth,
+} from "~/lib/date-utils";
+
+/**
+ * These helpers delegate to date-fns, which reads and writes *local* fields, by
+ * round-tripping through the UTC-naive frame. That round-trip is the whole risk:
+ * a slip would shift the calendar day in any zone that isn't UTC. Every
+ * assertion below therefore names an exact UTC-midnight instant, and the suite
+ * is meant to be run under hostile offsets (`TZ=Pacific/Kiritimati`, +14, and
+ * `TZ=Pacific/Midway`, -11) as well as UTC.
+ */
+
+const utc = (y: number, m: number, d: number) =>
+  new Date(Date.UTC(y, m - 1, d));
+
+describe("utcDateInMonth", () => {
+  it("returns the requested day when it exists in the month", () => {
+    expect(utcDateInMonth(utc(2026, 3, 1), 15)).toEqual(utc(2026, 3, 15));
+  });
+
+  it("reads only the year and month of its anchor, never the day", () => {
+    expect(utcDateInMonth(utc(2026, 3, 27), 5)).toEqual(utc(2026, 3, 5));
+  });
+
+  it("clamps backward to month end rather than rolling into the next month", () => {
+    // The load-bearing case: rolling forward would skip February entirely and
+    // put a BNPL statement in March.
+    expect(utcDateInMonth(utc(2026, 2, 1), 31)).toEqual(utc(2026, 2, 28));
+    expect(utcDateInMonth(utc(2026, 4, 1), 31)).toEqual(utc(2026, 4, 30));
+  });
+
+  it("clamps to 29 in a leap February", () => {
+    expect(utcDateInMonth(utc(2028, 2, 1), 31)).toEqual(utc(2028, 2, 29));
+  });
+
+  it("leaves days that exist in every month untouched", () => {
+    for (let month = 1; month <= 12; month++) {
+      expect(utcDateInMonth(utc(2026, month, 1), 28)).toEqual(
+        utc(2026, month, 28),
+      );
+    }
+  });
+});
+
+describe("startOfUtcMonth", () => {
+  it("floors to the first of the UTC month", () => {
+    expect(startOfUtcMonth(utc(2026, 8, 26))).toEqual(utc(2026, 8, 1));
+  });
+
+  it("is idempotent on a value already at the month start", () => {
+    expect(startOfUtcMonth(utc(2026, 8, 1))).toEqual(utc(2026, 8, 1));
+  });
+});
+
+describe("addUtcMonths", () => {
+  it("advances whole months, anchored on the 1st", () => {
+    expect(addUtcMonths(utc(2026, 8, 26), 2)).toEqual(utc(2026, 10, 1));
+  });
+
+  it("does not clamp when starting from a 31st", () => {
+    // date-fns `addMonths` would answer Feb 28 from Jan 31; anchoring on the
+    // 1st before adding means the result is the requested *month*, always.
+    expect(addUtcMonths(utc(2026, 1, 31), 1)).toEqual(utc(2026, 2, 1));
+  });
+
+  it("crosses year boundaries in both directions", () => {
+    expect(addUtcMonths(utc(2026, 11, 5), 3)).toEqual(utc(2027, 2, 1));
+    expect(addUtcMonths(utc(2026, 2, 5), -3)).toEqual(utc(2025, 11, 1));
+  });
+
+  it("returns the same month for a zero offset", () => {
+    expect(addUtcMonths(utc(2026, 8, 26), 0)).toEqual(utc(2026, 8, 1));
+  });
+
+  it("composes with utcDateInMonth the way the occurrence generator does", () => {
+    // monthlyOccurrencesInPeriod walks months with addUtcMonths and re-places
+    // the target day with utcDateInMonth. A 31st anchor must survive February.
+    const dtstart = utc(2026, 1, 31);
+    const days = [0, 1, 2, 3].map((i) =>
+      utcDateInMonth(addUtcMonths(dtstart, i), dtstart.getUTCDate()),
+    );
+
+    expect(days).toEqual([
+      utc(2026, 1, 31),
+      utc(2026, 2, 28),
+      utc(2026, 3, 31),
+      utc(2026, 4, 30),
+    ]);
+  });
+});
+
+describe("formatUtcDate", () => {
+  it("renders the UTC calendar day, not the viewer's", () => {
+    // The trap: `format` on a bare UTC-midnight instant reads local fields, so
+    // in any zone behind UTC it renders the *previous* day.
+    expect(formatUtcDate(utc(2026, 1, 1), "yyyy-MM-dd")).toBe("2026-01-01");
+    expect(formatUtcDate(utc(2026, 8, 26), "MMM d")).toBe("Aug 26");
+  });
+
+  it("round-trips the format the date input parses", () => {
+    const value = utc(2026, 2, 28);
+    expect(formatUtcDate(value, "yyyy-MM-dd")).toBe("2026-02-28");
+  });
+});

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,4 +1,11 @@
-import { format } from "date-fns";
+import { UTCDate } from "@date-fns/utc";
+import {
+  addMonths,
+  format,
+  getDaysInMonth,
+  setDate,
+  startOfMonth,
+} from "date-fns";
 
 /**
  * Date-only values in this app (bill `date`/`dtstart`/`until`, income
@@ -53,14 +60,39 @@ export function truncateToUtcDateOnly(date: Date): Date {
 
 /** Format a canonical (UTC-midnight) value by its calendar day, timezone-stably. */
 export function formatUtcDate(date: Date, formatStr: string): string {
-  return format(utcDateOnlyToLocal(date), formatStr);
+  return format(new UTCDate(date), formatStr);
 }
 
 /**
- * Canonical UTC-midnight date for `day` of the given UTC month (`month` is
- * 0-indexed), clamped *backward* when that day doesn't exist there: day 31 in
- * February yields Feb 28, or Feb 29 in a leap year. Rolling forward instead
- * would push the date into the next month and skip the intended one.
+ * Run a date-fns calculation in UTC and return a plain canonical `Date`.
+ *
+ * `UTCDate` carries its frame in the *value*, not in a per-call option: date-fns
+ * rebuilds results via `Symbol.for("constructDateFrom")`, so every function in a
+ * chain keeps reading and writing UTC fields. There is no `{ in: … }` to pass at
+ * each call site and therefore none to forget — the frame is structural, which
+ * is what lets these helpers delegate to date-fns instead of hand-rolling
+ * `Date.UTC` arithmetic.
+ *
+ * Measured in `Pacific/Midway` (−11) for `2026-01-31T00:00:00Z`:
+ * `startOfMonth(plainDate)` answers `2026-01-01T11:00:00Z` — the wrong day —
+ * while `startOfMonth(new UTCDate(d))` answers `2026-01-01T00:00:00Z`.
+ *
+ * The result is unwrapped to a plain `Date` because these values are written to
+ * MongoDB and cross SuperJSON. `UTCDate` is a `Date` subclass, so it would very
+ * likely survive both, but keeping the subclass out of the storage path costs
+ * one `getTime()` and removes the question.
+ */
+function inUtcFrame(date: Date, calculate: (utc: UTCDate) => Date): Date {
+  return new Date(calculate(new UTCDate(date)).getTime());
+}
+
+/**
+ * Canonical UTC-midnight date for `day` of the UTC month `monthOf` falls in,
+ * clamped *backward* when that day doesn't exist there: day 31 in February
+ * yields Feb 28, or Feb 29 in a leap year. Rolling forward instead would push
+ * the date into the next month and skip the intended one — which is why the day
+ * is pre-clamped rather than handed to `setDate`, whose native overflow rolls
+ * forward.
  *
  * This is the single spelling of "which day of this month" shared by the monthly
  * occurrence generator (`monthlyOccurrencesInPeriod`) and BNPL statement
@@ -69,21 +101,24 @@ export function formatUtcDate(date: Date, formatStr: string): string {
  * day from installments 2..N and its account would split into two statements a
  * month.
  */
-export function utcDateInMonth(year: number, month: number, day: number): Date {
-  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-  return new Date(Date.UTC(year, month, Math.min(day, lastDay)));
+export function utcDateInMonth(monthOf: Date, day: number): Date {
+  return inUtcFrame(monthOf, (utc) =>
+    setDate(utc, Math.min(day, getDaysInMonth(utc))),
+  );
 }
 
 /** First UTC-midnight day of the UTC month `date` falls in. */
 export function startOfUtcMonth(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+  return inUtcFrame(date, startOfMonth);
 }
 
-/** `date` advanced by `months` whole UTC months, anchored on the 1st. */
+/**
+ * `date` advanced by `months` whole UTC months, anchored on the 1st. Anchoring
+ * before adding means `addMonths`' own day-clamping never applies, so the result
+ * is the requested month even from a 31st.
+ */
 export function addUtcMonths(date: Date, months: number): Date {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
-  );
+  return inUtcFrame(date, (utc) => addMonths(startOfMonth(utc), months));
 }
 
 /**

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -57,6 +57,36 @@ export function formatUtcDate(date: Date, formatStr: string): string {
 }
 
 /**
+ * Canonical UTC-midnight date for `day` of the given UTC month (`month` is
+ * 0-indexed), clamped *backward* when that day doesn't exist there: day 31 in
+ * February yields Feb 28, or Feb 29 in a leap year. Rolling forward instead
+ * would push the date into the next month and skip the intended one.
+ *
+ * This is the single spelling of "which day of this month" shared by the monthly
+ * occurrence generator (`monthlyOccurrencesInPeriod`) and BNPL statement
+ * derivation (`deriveStatementDtstart`). The two must answer identically: if
+ * they ever disagreed, a purchase's first statement would land on a different
+ * day from installments 2..N and its account would split into two statements a
+ * month.
+ */
+export function utcDateInMonth(year: number, month: number, day: number): Date {
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(day, lastDay)));
+}
+
+/** First UTC-midnight day of the UTC month `date` falls in. */
+export function startOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+/** `date` advanced by `months` whole UTC months, anchored on the 1st. */
+export function addUtcMonths(date: Date, months: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+  );
+}
+
+/**
  * Parse a native `<input type="date">` value (`"yyyy-MM-dd"`, or `""` when
  * cleared) into a canonical UTC-midnight `Date`, or `undefined` when empty or
  * invalid. The inverse of rendering with `formatUtcDate(value, "yyyy-MM-dd")`:

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,5 +19,5 @@ export default async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard", "/playground", "/groups"], // Specify the routes the middleware applies to
+  matcher: ["/dashboard", "/playground", "/groups", "/bnpl"], // Specify the routes the middleware applies to
 };

--- a/src/schemas/bnpl.ts
+++ b/src/schemas/bnpl.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+// `dueDay` accepts 1–31 even though short months lack 29–31. The day is clamped
+// backward when a statement date is derived (see `deriveStatementDtstart`), so
+// storing the user's intent verbatim is correct — rejecting 31 would stop them
+// modelling a real end-of-month cycle.
+const dueDaySchema = z.number().int().min(1).max(31);
+const accountNameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Name is required" })
+  .max(50);
+
+export const CreateBnplAccountInputSchema = z.object({
+  name: accountNameSchema,
+  dueDay: dueDaySchema,
+});
+
+export const UpdateBnplAccountInputSchema = z.object({
+  id: z.string(),
+  data: z.object({
+    name: accountNameSchema.optional(),
+    dueDay: dueDaySchema.optional(),
+  }),
+});
+
+// `purchases` has no default on purpose: deleting an account is destructive in
+// one direction and merely untidy in the other, so the caller must state which
+// it wants rather than inheriting a choice made here.
+export const DeleteBnplAccountInputSchema = z.object({
+  id: z.string(),
+  purchases: z.enum(["delete", "keep"]),
+});
+
+export type CreateBnplAccountInput = z.infer<
+  typeof CreateBnplAccountInputSchema
+>;
+export type UpdateBnplAccountInput = z.infer<
+  typeof UpdateBnplAccountInputSchema
+>;

--- a/src/schemas/bnpl.ts
+++ b/src/schemas/bnpl.ts
@@ -38,3 +38,33 @@ export type CreateBnplAccountInput = z.infer<
 export type UpdateBnplAccountInput = z.infer<
   typeof UpdateBnplAccountInputSchema
 >;
+
+// A purchase's schedule is not accepted from the client: only its first *month*
+// is, and the day comes from the account. That's what makes one consolidated
+// statement per month impossible to violate rather than merely discouraged.
+const purchaseFieldsSchema = z.object({
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  // Required, unlike the shared bill schema's optional amount — an installment
+  // with no amount can't contribute to a statement total.
+  amount: z.number().min(1, { message: "Amount is required" }),
+  tenureMonths: z.number().int().min(1).max(60),
+  firstDueMonth: z.date(),
+});
+
+export const CreateBnplPurchaseInputSchema = purchaseFieldsSchema.extend({
+  accountId: z.string(),
+});
+
+export const UpdateBnplPurchaseInputSchema = z.object({
+  id: z.string(),
+  data: purchaseFieldsSchema,
+});
+
+export const DeleteBnplPurchaseInputSchema = z.object({ id: z.string() });
+
+export type CreateBnplPurchaseInput = z.infer<
+  typeof CreateBnplPurchaseInputSchema
+>;
+export type UpdateBnplPurchaseInput = z.infer<
+  typeof UpdateBnplPurchaseInputSchema
+>;

--- a/src/server/api/bill-cascade.ts
+++ b/src/server/api/bill-cascade.ts
@@ -13,6 +13,11 @@ import type { Db, ObjectId } from "mongodb";
  * but their mutations live in the BNPL router, so without this helper the same
  * rule would be written twice and remembered once.
  *
+ * Markers are deleted before bills, not after: if the bills delete were to
+ * throw partway, deleting markers first leaves a benign state (occurrences
+ * simply show unpaid and can be re-marked) rather than the orphaned-marker
+ * state this function exists to avoid.
+ *
  * Returns the number of bills actually deleted, so callers can distinguish
  * "not found" from "deleted".
  */
@@ -23,13 +28,13 @@ export async function deleteBillsWithPayments(
 ): Promise<number> {
   if (billOids.length === 0) return 0;
 
-  const result = await db
-    .collection("bills")
-    .deleteMany({ _id: { $in: billOids }, userId: userOid });
-
   await db
     .collection("payments")
     .deleteMany({ userId: userOid, billId: { $in: billOids } });
+
+  const result = await db
+    .collection("bills")
+    .deleteMany({ _id: { $in: billOids }, userId: userOid });
 
   return result.deletedCount;
 }

--- a/src/server/api/bill-cascade.ts
+++ b/src/server/api/bill-cascade.ts
@@ -1,0 +1,35 @@
+import type { Db, ObjectId } from "mongodb";
+
+/**
+ * Delete bills together with the paid-occurrence markers pointing at them.
+ *
+ * A `payments` document is a small marker meaning "this bill's occurrence on
+ * this date is settled" — it carries no amount, only that pairing. Occurrences
+ * are generated from a bill's recurrence rather than stored, so a marker is
+ * only meaningful while its bill exists. Deleting a bill without its markers
+ * leaves rows nothing can render and nothing can clear.
+ *
+ * Shared by the bill router and the BNPL router: purchases are `bills` rows,
+ * but their mutations live in the BNPL router, so without this helper the same
+ * rule would be written twice and remembered once.
+ *
+ * Returns the number of bills actually deleted, so callers can distinguish
+ * "not found" from "deleted".
+ */
+export async function deleteBillsWithPayments(
+  db: Db,
+  userOid: ObjectId,
+  billOids: ObjectId[],
+): Promise<number> {
+  if (billOids.length === 0) return 0;
+
+  const result = await db
+    .collection("bills")
+    .deleteMany({ _id: { $in: billOids }, userId: userOid });
+
+  await db
+    .collection("payments")
+    .deleteMany({ userId: userOid, billId: { $in: billOids } });
+
+  return result.deletedCount;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,4 +1,5 @@
 import { billRouter } from "~/server/api/routers/bill";
+import { bnplRouter } from "~/server/api/routers/bnpl";
 import { groupRouter } from "~/server/api/routers/group";
 import { paymentRouter } from "~/server/api/routers/payment";
 import { postRouter } from "~/server/api/routers/post";
@@ -13,6 +14,7 @@ import { incomeRouter } from "./routers/income";
 export const appRouter = createTRPCRouter({
   post: postRouter,
   bill: billRouter,
+  bnpl: bnplRouter,
   group: groupRouter,
   income: incomeRouter,
   payment: paymentRouter,

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -22,6 +22,9 @@ type BillEvent = Simplify<
     _id: ObjectId;
     userId: ObjectId;
     groupId?: ObjectId | null;
+    // Present only on BNPL purchases (see `bnplRouter`); typed here so the
+    // `update` mutation's filter can exclude them without an `as` cast.
+    bnplAccountId?: ObjectId;
   } & Omit<InputBill, "groupId">
 >;
 
@@ -114,6 +117,14 @@ export const billRouter = createTRPCRouter({
         {
           _id: new ObjectId(input.id),
           userId: new ObjectId(ctx.session.user.id),
+          // This mutation accepts a client-supplied `recurrence`, including
+          // `dtstart` — a BNPL purchase's `dtstart` must only ever be derived
+          // server-side from its account's due day, since that derivation is
+          // what makes a split statement unrepresentable. Excluding purchases
+          // from the filter (rather than checking after the fact) makes a
+          // purchase id read as the existing "Bill not found"; purchase edits
+          // belong to `bnpl.updatePurchase`.
+          bnplAccountId: { $exists: false },
         },
         setOps,
       );

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -4,6 +4,7 @@ import type { Simplify } from "type-fest";
 import { z } from "zod";
 import { RecurringBillSchema, SingleBillSchema } from "~/schemas/bill";
 import type { BillEvent as SerializedBillEvent } from "~/types";
+import { deleteBillsWithPayments } from "../bill-cascade";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const InputBillSchema = z
@@ -128,21 +129,15 @@ export const billRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
       }
 
-      const billOid = new ObjectId(input.id);
-      const userOid = new ObjectId(ctx.session.user.id);
-      const result = await ctx.db
-        .collection("bills")
-        .deleteOne({ _id: billOid, userId: userOid });
+      const deleted = await deleteBillsWithPayments(
+        ctx.db,
+        new ObjectId(ctx.session.user.id),
+        [new ObjectId(input.id)],
+      );
 
-      if (result.deletedCount === 0) {
+      if (deleted === 0) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
       }
-
-      // Cascade: drop any paid-occurrence markers for this bill so they don't
-      // orphan in the payments collection.
-      await ctx.db
-        .collection("payments")
-        .deleteMany({ userId: userOid, billId: billOid });
     }),
   create: protectedProcedure
     .input(InputBillSchema)

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -28,6 +28,27 @@ type BillEvent = Simplify<
   } & Omit<InputBill, "groupId">
 >;
 
+/**
+ * "This row is an ordinary bill, not a BNPL purchase" — the server-side spelling
+ * of the discriminator `partitionBills` applies on the client, and its exact
+ * complement `IS_PURCHASE`. Every mutation that must not reshape a purchase
+ * filters on this one constant rather than inlining its own predicate.
+ *
+ * Matches a missing field, an explicit `null`, and `""` — all three of which
+ * `BillEvent.bnplAccountId` (`?: string | null`) admits and `partitionBills`
+ * treats as ordinary. A bare `$exists: false` would call a null-valued row a
+ * purchase, leaving a bill that renders and opens normally but can never be
+ * saved.
+ */
+export const NOT_A_PURCHASE = {
+  bnplAccountId: { $not: { $type: "objectId" } },
+} as const;
+
+/** A BNPL purchase row: `bnplAccountId` holds a real account ObjectId. */
+export const IS_PURCHASE = {
+  bnplAccountId: { $type: "objectId" },
+} as const;
+
 type GroupDoc = {
   _id: ObjectId;
   userId: ObjectId;
@@ -124,7 +145,7 @@ export const billRouter = createTRPCRouter({
           // from the filter (rather than checking after the fact) makes a
           // purchase id read as the existing "Bill not found"; purchase edits
           // belong to `bnpl.updatePurchase`.
-          bnplAccountId: { $exists: false },
+          ...NOT_A_PURCHASE,
         },
         setOps,
       );
@@ -140,11 +161,25 @@ export const billRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
       }
 
-      const deleted = await deleteBillsWithPayments(
-        ctx.db,
-        new ObjectId(ctx.session.user.id),
-        [new ObjectId(input.id)],
-      );
+      // Purchase deletion belongs to `bnpl.deletePurchase`, which is the only
+      // endpoint that knows a purchase is one member of a statement. Excluding
+      // them here keeps this mutation symmetric with `update`/`assignGroup`
+      // rather than being a second, undocumented way to delete one.
+      const userOid = new ObjectId(ctx.session.user.id);
+      const ordinary = await ctx.db
+        .collection<BillEvent>("bills")
+        .findOne(
+          { _id: new ObjectId(input.id), userId: userOid, ...NOT_A_PURCHASE },
+          { projection: { _id: 1 } },
+        );
+
+      if (!ordinary) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
+      }
+
+      const deleted = await deleteBillsWithPayments(ctx.db, userOid, [
+        ordinary._id,
+      ]);
 
       if (deleted === 0) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Bill not found" });
@@ -179,6 +214,11 @@ export const billRouter = createTRPCRouter({
         {
           _id: new ObjectId(input.id),
           userId: new ObjectId(ctx.session.user.id),
+          // Same exclusion as `update`: a BNPL purchase has no place in a group.
+          // `partitionBills` routes it out of every group section, so a groupId
+          // stamped here would never render but would still inflate the group's
+          // bill count on /groups.
+          ...NOT_A_PURCHASE,
         },
         setOps,
       );

--- a/src/server/api/routers/bnpl.ts
+++ b/src/server/api/routers/bnpl.ts
@@ -282,10 +282,20 @@ export const bnplRouter = createTRPCRouter({
 
       const userOid = new ObjectId(ctx.session.user.id);
       const purchase = await ctx.db
-        .collection<{ _id: ObjectId; bnplAccountId?: ObjectId }>("bills")
+        .collection<{
+          _id: ObjectId;
+          bnplAccountId?: ObjectId;
+          recurrence?: { dtstart: Date; count?: number };
+        }>("bills")
         .findOne(
           { _id: new ObjectId(input.id), userId: userOid },
-          { projection: { bnplAccountId: 1 } },
+          {
+            projection: {
+              bnplAccountId: 1,
+              "recurrence.dtstart": 1,
+              "recurrence.count": 1,
+            },
+          },
         );
 
       // Guard on bnplAccountId, not just existence: this endpoint must not be
@@ -302,6 +312,14 @@ export const bnplRouter = createTRPCRouter({
         purchase.bnplAccountId.toHexString(),
       );
 
+      const previousDtstart = purchase.recurrence?.dtstart;
+      const previousCount = purchase.recurrence?.count;
+      const nextDtstart = deriveStatementDtstart(
+        dueDay,
+        input.data.firstDueMonth,
+      );
+      const nextCount = input.data.tenureMonths;
+
       await ctx.db.collection("bills").updateOne(
         { _id: purchase._id, userId: userOid },
         {
@@ -312,12 +330,56 @@ export const bnplRouter = createTRPCRouter({
             recurrence: {
               type: "monthly",
               interval: 1,
-              dtstart: deriveStatementDtstart(dueDay, input.data.firstDueMonth),
-              count: input.data.tenureMonths,
+              dtstart: nextDtstart,
+              count: nextCount,
             },
           },
         },
       );
+
+      // Reconcile paid-markers against the new schedule. Markers are keyed on
+      // (billId, occurrenceDate); if the schedule they point at no longer
+      // produces that occurrence, they become unrenderable and thus
+      // unclearable (see edge case 6 in the design doc).
+      if (
+        previousDtstart &&
+        previousDtstart.getTime() !== nextDtstart.getTime()
+      ) {
+        // The first month moved, not just the day-of-month. Unlike the
+        // due-day path (which only shifts the day and keeps every marker's
+        // month, so shifting markers the same way preserves them), a
+        // first-month change redefines which month is installment 1 — a
+        // marker for "March" would silently become a marker for whatever
+        // installment now falls in March. There is no correct shift, so
+        // every marker for this bill is deleted rather than moved: the
+        // schedule was redefined and prior paid records no longer correspond
+        // to anything the user can see.
+        await ctx.db
+          .collection("payments")
+          .deleteMany({ userId: userOid, billId: purchase._id });
+      } else if (previousCount !== undefined && nextCount < previousCount) {
+        // Only the tenure shrank. Markers for installments that still exist
+        // stay valid; only markers past the new final occurrence are stale.
+        // Reuse the tested statement-derivation helper (with the same
+        // month-end clamping the generator applies) rather than hand-rolling
+        // the month arithmetic.
+        const finalMonth = new Date(
+          Date.UTC(
+            nextDtstart.getUTCFullYear(),
+            nextDtstart.getUTCMonth() + nextCount - 1,
+            1,
+          ),
+        );
+        const newFinalOccurrence = deriveStatementDtstart(dueDay, finalMonth);
+
+        await ctx.db.collection("payments").deleteMany({
+          userId: userOid,
+          billId: purchase._id,
+          occurrenceDate: { $gt: newFinalOccurrence },
+        });
+      }
+      // Otherwise (title/amount only, or a tenure increase): no schedule
+      // change reaches an existing occurrence, so markers stay untouched.
     }),
 
   deletePurchase: protectedProcedure

--- a/src/server/api/routers/bnpl.ts
+++ b/src/server/api/routers/bnpl.ts
@@ -19,15 +19,20 @@ export type BnplAccountDoc = {
 };
 
 // Minimal shape of a purchase document this router reads back when rewriting
-// schedules. Purchases are `bills` rows; see the bill router for the full type.
+// schedules or resolving which bills belong to an account. Purchases are
+// `bills` rows; see the bill router for the full type. `bnplAccountId` is
+// typed here (rather than left to an untyped filter) so a typo in the field
+// name fails the compiler instead of silently matching zero documents — every
+// purchase query in this router filters on it.
 type PurchaseDoc = {
   _id: ObjectId;
+  bnplAccountId?: ObjectId;
   recurrence?: { dtstart?: Date };
 };
 
 /**
  * Confirms the account exists and belongs to the requesting user. Mirrors
- * `resolveGroupId` in the bill router. Returns the resolved ids so callers
+ * `assertBillOwned` in the payment router. Returns the resolved ids so callers
  * don't re-parse them.
  */
 export async function assertAccountOwned(
@@ -156,6 +161,44 @@ export const bnplRouter = createTRPCRouter({
       if (ops.length > 0) {
         await ctx.db.collection("bills").bulkWrite(ops);
       }
+
+      // Paid-markers are keyed on (billId, occurrenceDate), so moving dtstart
+      // moves the occurrences they point at. Left alone, every paid installment
+      // would revert to unpaid and the stale rows could never be cleared —
+      // markUnpaid needs the occurrence rendered before it can be clicked.
+      // Shift them by the same transform that moved dtstart: month kept, day
+      // replaced. A bill has at most one occurrence per month, so two markers
+      // for one bill always differ in month and can never collide on the new date.
+      const billOids = purchases.map((purchase) => purchase._id);
+      if (billOids.length > 0) {
+        const markerCursor = ctx.db
+          .collection<{
+            _id: ObjectId;
+            billId: ObjectId;
+            occurrenceDate: Date;
+          }>("payments")
+          .find({ userId: userOid, billId: { $in: billOids } });
+        const markers = await markerCursor.toArray();
+        await markerCursor.close();
+
+        const markerOps = markers.map((marker) => ({
+          updateOne: {
+            filter: { _id: marker._id, userId: userOid },
+            update: {
+              $set: {
+                occurrenceDate: deriveStatementDtstart(
+                  nextDueDay,
+                  marker.occurrenceDate,
+                ),
+              },
+            },
+          },
+        }));
+
+        if (markerOps.length > 0) {
+          await ctx.db.collection("payments").bulkWrite(markerOps);
+        }
+      }
     }),
 
   delete: protectedProcedure
@@ -165,7 +208,7 @@ export const bnplRouter = createTRPCRouter({
 
       if (input.purchases === "delete") {
         const cursor = ctx.db
-          .collection<{ _id: ObjectId }>("bills")
+          .collection<PurchaseDoc>("bills")
           .find(
             { userId: userOid, bnplAccountId: accountOid },
             { projection: { _id: 1 } },

--- a/src/server/api/routers/bnpl.ts
+++ b/src/server/api/routers/bnpl.ts
@@ -3,8 +3,11 @@ import { ObjectId, type Db, type WithoutId } from "mongodb";
 import { deriveStatementDtstart } from "~/lib/bnpl-utils";
 import {
   CreateBnplAccountInputSchema,
+  CreateBnplPurchaseInputSchema,
   DeleteBnplAccountInputSchema,
+  DeleteBnplPurchaseInputSchema,
   UpdateBnplAccountInputSchema,
+  UpdateBnplPurchaseInputSchema,
 } from "~/schemas/bnpl";
 import { deleteBillsWithPayments } from "../bill-cascade";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
@@ -241,5 +244,103 @@ export const bnplRouter = createTRPCRouter({
       await ctx.db
         .collection<BnplAccountDoc>("bnpl_accounts")
         .deleteOne({ _id: accountOid, userId: userOid });
+    }),
+
+  createPurchase: protectedProcedure
+    .input(CreateBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid, dueDay } = await assertAccountOwned(
+        ctx,
+        input.accountId,
+      );
+
+      await ctx.db.collection("bills").insertOne({
+        userId: userOid,
+        bnplAccountId: accountOid,
+        title: input.title,
+        amount: input.amount,
+        type: "recurring",
+        recurrence: {
+          type: "monthly",
+          interval: 1,
+          // Derived, never client-supplied: the account owns the day.
+          dtstart: deriveStatementDtstart(dueDay, input.firstDueMonth),
+          count: input.tenureMonths,
+        },
+      });
+    }),
+
+  updatePurchase: protectedProcedure
+    .input(UpdateBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ObjectId.isValid(input.id)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Purchase not found",
+        });
+      }
+
+      const userOid = new ObjectId(ctx.session.user.id);
+      const purchase = await ctx.db
+        .collection<{ _id: ObjectId; bnplAccountId?: ObjectId }>("bills")
+        .findOne(
+          { _id: new ObjectId(input.id), userId: userOid },
+          { projection: { bnplAccountId: 1 } },
+        );
+
+      // Guard on bnplAccountId, not just existence: this endpoint must not be
+      // usable to reshape an ordinary bill into an installment.
+      if (!purchase?.bnplAccountId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Purchase not found",
+        });
+      }
+
+      const { dueDay } = await assertAccountOwned(
+        ctx,
+        purchase.bnplAccountId.toHexString(),
+      );
+
+      await ctx.db.collection("bills").updateOne(
+        { _id: purchase._id, userId: userOid },
+        {
+          $set: {
+            title: input.data.title,
+            amount: input.data.amount,
+            type: "recurring",
+            recurrence: {
+              type: "monthly",
+              interval: 1,
+              dtstart: deriveStatementDtstart(dueDay, input.data.firstDueMonth),
+              count: input.data.tenureMonths,
+            },
+          },
+        },
+      );
+    }),
+
+  deletePurchase: protectedProcedure
+    .input(DeleteBnplPurchaseInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ObjectId.isValid(input.id)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Purchase not found",
+        });
+      }
+
+      const deleted = await deleteBillsWithPayments(
+        ctx.db,
+        new ObjectId(ctx.session.user.id),
+        [new ObjectId(input.id)],
+      );
+
+      if (deleted === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Purchase not found",
+        });
+      }
     }),
 });

--- a/src/server/api/routers/bnpl.ts
+++ b/src/server/api/routers/bnpl.ts
@@ -10,6 +10,7 @@ import {
   UpdateBnplPurchaseInputSchema,
 } from "~/schemas/bnpl";
 import { deleteBillsWithPayments } from "../bill-cascade";
+import { IS_PURCHASE } from "./bill";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 // DB representation — ObjectId fields. See ~/types `BnplAccount` for the
@@ -103,10 +104,13 @@ export const bnplRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
 
+      // Destructured once so `nextDueDay` narrows to `number` past the guard
+      // below, with no non-null assertion for the writes that follow.
+      const { name, dueDay: nextDueDay } = input.data;
+
       const updateFields: Partial<Pick<BnplAccountDoc, "name" | "dueDay">> = {};
-      if (input.data.name !== undefined) updateFields.name = input.data.name;
-      if (input.data.dueDay !== undefined)
-        updateFields.dueDay = input.data.dueDay;
+      if (name !== undefined) updateFields.name = name;
+      if (nextDueDay !== undefined) updateFields.dueDay = nextDueDay;
 
       if (Object.keys(updateFields).length === 0) return;
 
@@ -117,11 +121,6 @@ export const bnplRouter = createTRPCRouter({
           { $set: updateFields },
         );
 
-      // Hoisted before the early-return guard below so it stays a plain
-      // `number` for the flatMap, rather than reaching for `input.data.dueDay!`
-      // — `@typescript-eslint/no-non-null-assertion` forbids the assertion, and
-      // this hoist is provably equivalent since nothing reassigns `input`.
-      const nextDueDay = input.data.dueDay;
       if (nextDueDay === undefined) return;
 
       // A new due day must be applied to the purchases already under this
@@ -140,67 +139,73 @@ export const bnplRouter = createTRPCRouter({
       const purchases = await cursor.toArray();
       await cursor.close();
 
-      const ops = purchases.flatMap((purchase) => {
+      const ops: Array<{
+        updateOne: {
+          filter: { _id: ObjectId; userId: ObjectId };
+          update: { $set: { "recurrence.dtstart": Date } };
+        };
+      }> = [];
+      for (const purchase of purchases) {
         const dtstart = purchase.recurrence?.dtstart;
-        if (!dtstart) return [];
+        if (!dtstart) continue;
 
-        return [
-          {
-            updateOne: {
-              filter: { _id: purchase._id, userId: userOid },
-              update: {
-                $set: {
-                  "recurrence.dtstart": deriveStatementDtstart(
-                    nextDueDay,
-                    dtstart,
-                  ),
-                },
-              },
-            },
-          },
-        ];
-      });
-
-      if (ops.length > 0) {
-        await ctx.db.collection("bills").bulkWrite(ops);
-      }
-
-      // Paid-markers are keyed on (billId, occurrenceDate), so moving dtstart
-      // moves the occurrences they point at. Left alone, every paid installment
-      // would revert to unpaid and the stale rows could never be cleared —
-      // markUnpaid needs the occurrence rendered before it can be clicked.
-      // Shift them by the same transform that moved dtstart: month kept, day
-      // replaced. A bill has at most one occurrence per month, so two markers
-      // for one bill always differ in month and can never collide on the new date.
-      const billOids = purchases.map((purchase) => purchase._id);
-      if (billOids.length > 0) {
-        const markerCursor = ctx.db
-          .collection<{
-            _id: ObjectId;
-            billId: ObjectId;
-            occurrenceDate: Date;
-          }>("payments")
-          .find({ userId: userOid, billId: { $in: billOids } });
-        const markers = await markerCursor.toArray();
-        await markerCursor.close();
-
-        const markerOps = markers.map((marker) => ({
+        ops.push({
           updateOne: {
-            filter: { _id: marker._id, userId: userOid },
+            filter: { _id: purchase._id, userId: userOid },
             update: {
               $set: {
-                occurrenceDate: deriveStatementDtstart(
+                "recurrence.dtstart": deriveStatementDtstart(
                   nextDueDay,
-                  marker.occurrenceDate,
+                  dtstart,
                 ),
               },
             },
           },
-        }));
+        });
+      }
 
-        if (markerOps.length > 0) {
-          await ctx.db.collection("payments").bulkWrite(markerOps);
-        }
+      // Guarded because bulkWrite rejects an empty operations array.
+      if (ops.length > 0) {
+        await ctx.db.collection("bills").bulkWrite(ops);
+      }
+
+      // Paid-markers are keyed on (billId, occurrenceDate), and an installment's
+      // marker sits on its *statement* date — the account's due day clamped into
+      // that month (see `groupStatements`). Moving the due day therefore moves
+      // every marker, by the same month-preserving transform: month kept, day
+      // re-derived. Left alone, every paid installment would revert to unpaid
+      // and the stale rows could never be cleared, since markUnpaid needs the
+      // occurrence rendered before it can be clicked.
+      //
+      // A bill has at most one statement per month, so two markers for one bill
+      // always differ in month and can never collide on the new date.
+      const billOids = purchases.map((purchase) => purchase._id);
+      const markerCursor = ctx.db
+        .collection<{
+          _id: ObjectId;
+          billId: ObjectId;
+          occurrenceDate: Date;
+        }>("payments")
+        .find({ userId: userOid, billId: { $in: billOids } });
+      const markers = await markerCursor.toArray();
+      await markerCursor.close();
+
+      const markerOps = markers.map((marker) => ({
+        updateOne: {
+          filter: { _id: marker._id, userId: userOid },
+          update: {
+            $set: {
+              occurrenceDate: deriveStatementDtstart(
+                nextDueDay,
+                marker.occurrenceDate,
+              ),
+            },
+          },
+        },
+      }));
+
+      if (markerOps.length > 0) {
+        await ctx.db.collection("payments").bulkWrite(markerOps);
       }
     }),
 
@@ -392,17 +397,25 @@ export const bnplRouter = createTRPCRouter({
         });
       }
 
-      const deleted = await deleteBillsWithPayments(
-        ctx.db,
-        new ObjectId(ctx.session.user.id),
-        [new ObjectId(input.id)],
-      );
+      const userOid = new ObjectId(ctx.session.user.id);
+      // Guard on bnplAccountId, not just existence — the same rule
+      // `updatePurchase` states. Without it this endpoint deletes any bill the
+      // user owns, plus its entire paid-occurrence history, while reporting
+      // under a "Purchase not found" / "Purchase deleted" contract.
+      const purchase = await ctx.db
+        .collection<PurchaseDoc>("bills")
+        .findOne(
+          { _id: new ObjectId(input.id), userId: userOid, ...IS_PURCHASE },
+          { projection: { _id: 1 } },
+        );
 
-      if (deleted === 0) {
+      if (!purchase) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Purchase not found",
         });
       }
+
+      await deleteBillsWithPayments(ctx.db, userOid, [purchase._id]);
     }),
 });

--- a/src/server/api/routers/bnpl.ts
+++ b/src/server/api/routers/bnpl.ts
@@ -1,0 +1,202 @@
+import { TRPCError } from "@trpc/server";
+import { ObjectId, type Db, type WithoutId } from "mongodb";
+import { deriveStatementDtstart } from "~/lib/bnpl-utils";
+import {
+  CreateBnplAccountInputSchema,
+  DeleteBnplAccountInputSchema,
+  UpdateBnplAccountInputSchema,
+} from "~/schemas/bnpl";
+import { deleteBillsWithPayments } from "../bill-cascade";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+// DB representation — ObjectId fields. See ~/types `BnplAccount` for the
+// domain shape.
+export type BnplAccountDoc = {
+  _id: ObjectId;
+  userId: ObjectId;
+  name: string;
+  dueDay: number;
+};
+
+// Minimal shape of a purchase document this router reads back when rewriting
+// schedules. Purchases are `bills` rows; see the bill router for the full type.
+type PurchaseDoc = {
+  _id: ObjectId;
+  recurrence?: { dtstart?: Date };
+};
+
+/**
+ * Confirms the account exists and belongs to the requesting user. Mirrors
+ * `resolveGroupId` in the bill router. Returns the resolved ids so callers
+ * don't re-parse them.
+ */
+export async function assertAccountOwned(
+  ctx: { db: Db; session: { user: { id: string } } },
+  accountId: string,
+): Promise<{ accountOid: ObjectId; userOid: ObjectId; dueDay: number }> {
+  if (!ObjectId.isValid(accountId)) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Account not found" });
+  }
+
+  const accountOid = new ObjectId(accountId);
+  const userOid = new ObjectId(ctx.session.user.id);
+  const found = await ctx.db
+    .collection<BnplAccountDoc>("bnpl_accounts")
+    .findOne(
+      { _id: accountOid, userId: userOid },
+      { projection: { dueDay: 1 } },
+    );
+
+  if (!found) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Account not found" });
+  }
+
+  return { accountOid, userOid, dueDay: found.dueDay };
+}
+
+export const bnplRouter = createTRPCRouter({
+  getAll: protectedProcedure.query(async ({ ctx }) => {
+    // Sorted by _id: ObjectIds are timestamp-prefixed, so this is a stable
+    // creation-order sort with no `order` field to write or keep consistent.
+    const cursor = ctx.db
+      .collection<BnplAccountDoc>("bnpl_accounts")
+      .find({ userId: new ObjectId(ctx.session.user.id) })
+      .sort({ _id: 1 });
+    const accounts = await cursor.toArray();
+    await cursor.close();
+
+    return accounts.map((a) => ({
+      _id: a._id.toHexString(),
+      userId: a.userId.toHexString(),
+      name: a.name,
+      dueDay: a.dueDay,
+    }));
+  }),
+
+  create: protectedProcedure
+    .input(CreateBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const userId = new ObjectId(ctx.session.user.id);
+
+      const result = await ctx.db
+        .collection<WithoutId<BnplAccountDoc>>("bnpl_accounts")
+        .insertOne({ userId, name: input.name, dueDay: input.dueDay });
+
+      return {
+        _id: result.insertedId.toHexString(),
+        userId: userId.toHexString(),
+        name: input.name,
+        dueDay: input.dueDay,
+      };
+    }),
+
+  update: protectedProcedure
+    .input(UpdateBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
+
+      const updateFields: Partial<Pick<BnplAccountDoc, "name" | "dueDay">> = {};
+      if (input.data.name !== undefined) updateFields.name = input.data.name;
+      if (input.data.dueDay !== undefined)
+        updateFields.dueDay = input.data.dueDay;
+
+      if (Object.keys(updateFields).length === 0) return;
+
+      await ctx.db
+        .collection<BnplAccountDoc>("bnpl_accounts")
+        .updateOne(
+          { _id: accountOid, userId: userOid },
+          { $set: updateFields },
+        );
+
+      // Hoisted before the early-return guard below so it stays a plain
+      // `number` for the flatMap, rather than reaching for `input.data.dueDay!`
+      // — `@typescript-eslint/no-non-null-assertion` forbids the assertion, and
+      // this hoist is provably equivalent since nothing reassigns `input`.
+      const nextDueDay = input.data.dueDay;
+      if (nextDueDay === undefined) return;
+
+      // A new due day must be applied to the purchases already under this
+      // account, not just to future ones. Otherwise old purchases keep firing
+      // on the previous day while new ones fire on the new day, and the account
+      // silently splits into two statements a month — precisely what deriving
+      // `dtstart` from the account exists to prevent.
+      //
+      // Each purchase keeps its own first *month*; only the day-of-month moves.
+      const cursor = ctx.db
+        .collection<PurchaseDoc>("bills")
+        .find(
+          { userId: userOid, bnplAccountId: accountOid },
+          { projection: { "recurrence.dtstart": 1 } },
+        );
+      const purchases = await cursor.toArray();
+      await cursor.close();
+
+      const ops = purchases.flatMap((purchase) => {
+        const dtstart = purchase.recurrence?.dtstart;
+        if (!dtstart) return [];
+
+        return [
+          {
+            updateOne: {
+              filter: { _id: purchase._id, userId: userOid },
+              update: {
+                $set: {
+                  "recurrence.dtstart": deriveStatementDtstart(
+                    nextDueDay,
+                    dtstart,
+                  ),
+                },
+              },
+            },
+          },
+        ];
+      });
+
+      if (ops.length > 0) {
+        await ctx.db.collection("bills").bulkWrite(ops);
+      }
+    }),
+
+  delete: protectedProcedure
+    .input(DeleteBnplAccountInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { accountOid, userOid } = await assertAccountOwned(ctx, input.id);
+
+      if (input.purchases === "delete") {
+        const cursor = ctx.db
+          .collection<{ _id: ObjectId }>("bills")
+          .find(
+            { userId: userOid, bnplAccountId: accountOid },
+            { projection: { _id: 1 } },
+          );
+        const purchases = await cursor.toArray();
+        await cursor.close();
+
+        await deleteBillsWithPayments(
+          ctx.db,
+          userOid,
+          purchases.map((p) => p._id),
+        );
+      } else {
+        // Keep: drop only the account reference, so each purchase becomes an
+        // ordinary monthly recurring bill. Its `count` still ends it at the
+        // close of its tenure.
+        //
+        // `payments` is deliberately untouched — the bill ids don't change, so
+        // every existing paid-marker stays valid and correctly attached.
+        await ctx.db
+          .collection("bills")
+          .updateMany(
+            { userId: userOid, bnplAccountId: accountOid },
+            { $unset: { bnplAccountId: "" } },
+          );
+      }
+
+      // Purchases are handled first so a failure here can be retried without
+      // having already orphaned them — the same ordering as `group.delete`.
+      await ctx.db
+        .collection<BnplAccountDoc>("bnpl_accounts")
+        .deleteOne({ _id: accountOid, userId: userOid });
+    }),
+});

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { truncateToUtcDateOnly } from "~/lib/date-utils";
 import type { Payment as SerializedPayment } from "~/types";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { assertAccountOwned } from "./bnpl";
 
 // A payment marks one *occurrence* of a bill as settled. Occurrences aren't
 // stored rows — they're generated on the fly from the bill's recurrence rule —
@@ -50,6 +51,35 @@ async function assertBillOwned(
   return { billOid, userOid };
 }
 
+// A statement is settled as a unit, so its mutations act on a set of bill ids.
+// Every id must belong to the requesting user *and* to the named account —
+// otherwise this endpoint would be a way to write payments against arbitrary
+// bills in bulk.
+async function assertPurchasesInAccount(
+  ctx: { db: Db; session: { user: { id: string } } },
+  accountId: string,
+  billIds: string[],
+): Promise<{ billOids: ObjectId[]; userOid: ObjectId }> {
+  const { accountOid, userOid } = await assertAccountOwned(ctx, accountId);
+
+  if (billIds.some((id) => !ObjectId.isValid(id))) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+  }
+
+  const billOids = billIds.map((id) => new ObjectId(id));
+  const matched = await ctx.db.collection("bills").countDocuments({
+    _id: { $in: billOids },
+    userId: userOid,
+    bnplAccountId: accountOid,
+  });
+
+  if (matched !== billOids.length) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
+  }
+
+  return { billOids, userOid };
+}
+
 export const paymentRouter = createTRPCRouter({
   getAll: protectedProcedure.query(async ({ ctx }) => {
     const cursor = ctx.db
@@ -87,6 +117,59 @@ export const paymentRouter = createTRPCRouter({
         userId: userOid,
         billId: billOid,
         occurrenceDate: truncateToUtcDateOnly(input.occurrenceDate),
+      });
+    }),
+  markStatementPaid: protectedProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        statementDate: z.date(),
+        billIds: z.array(z.string()).min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { billOids, userOid } = await assertPurchasesInAccount(
+        ctx,
+        input.accountId,
+        input.billIds,
+      );
+      const occurrenceDate = truncateToUtcDateOnly(input.statementDate);
+
+      // One bulkWrite rather than N client mutations: a statement is a single
+      // user action and shouldn't be able to land half-applied because a
+      // request in the middle failed.
+      await ctx.db.collection("payments").bulkWrite(
+        billOids.map((billId) => ({
+          updateOne: {
+            filter: { userId: userOid, billId, occurrenceDate },
+            update: { $set: { paidAt: new Date() } },
+            upsert: true,
+          },
+        })),
+      );
+    }),
+
+  markStatementUnpaid: protectedProcedure
+    .input(
+      z.object({
+        accountId: z.string(),
+        statementDate: z.date(),
+        billIds: z.array(z.string()).min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { billOids, userOid } = await assertPurchasesInAccount(
+        ctx,
+        input.accountId,
+        input.billIds,
+      );
+
+      // deleteMany, mirroring markUnpaid: self-heals any duplicate a concurrent
+      // upsert race may have created.
+      await ctx.db.collection("payments").deleteMany({
+        userId: userOid,
+        billId: { $in: billOids },
+        occurrenceDate: truncateToUtcDateOnly(input.statementDate),
       });
     }),
 });

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -62,11 +62,16 @@ async function assertPurchasesInAccount(
 ): Promise<{ billOids: ObjectId[]; userOid: ObjectId }> {
   const { accountOid, userOid } = await assertAccountOwned(ctx, accountId);
 
-  if (billIds.some((id) => !ObjectId.isValid(id))) {
+  // Dedupe before counting: a repeated id would otherwise make countDocuments'
+  // distinct-document match fall short of the raw input length and reject a
+  // valid request. The deduped list is also what gets queried and written.
+  const uniqueIds = [...new Set(billIds)];
+
+  if (uniqueIds.some((id) => !ObjectId.isValid(id))) {
     throw new TRPCError({ code: "NOT_FOUND", message: "Purchase not found" });
   }
 
-  const billOids = billIds.map((id) => new ObjectId(id));
+  const billOids = uniqueIds.map((id) => new ObjectId(id));
   const matched = await ctx.db.collection("bills").countDocuments({
     _id: { $in: billOids },
     userId: userOid,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,10 @@ export type BillEvent = {
   amount?: number;
   userId: string;
   groupId?: string | null;
+  // Present = this bill is a BNPL installment purchase, and names the account
+  // it belongs to. Absent = an ordinary bill. Presence is the only
+  // discriminator, which is why no migration was needed to introduce it.
+  bnplAccountId?: string | null;
 } & (Single | Recurring);
 
 // PlaygroundBillData: bill fields without the local id.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,17 @@ export type PlaygroundBill =
       recurrence: Recurrence;
     };
 
+// A BNPL provider account (Shopee SPayLater, LazPayLater, …). The account owns
+// the shared monthly `dueDay`: every purchase under it derives its schedule from
+// that day, which is what makes one consolidated statement per month structural
+// rather than a data-entry convention.
+export interface BnplAccount {
+  _id: string;
+  userId: string;
+  name: string;
+  dueDay: number;
+}
+
 export interface IncomeProfile {
   payFrequency: "weekly" | "fortnightly" | "monthly";
   startDate: Date;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements **#44** — a first-class home for BNPL installment items (Shopee SPayLater, LazPayLater, et al.) so they stop flooding the pay-period bill list.

The core insight from brainstorming: a BNPL provider **consolidates**. You don't owe eight separate installments this month — you owe one statement, on one date, with one payment. So instead of a per-item view, the feature models **BNPL accounts**, and the dashboard shows one dated roll-up row per account per period.

Closes #44.

## Model — no migration

| Collection | Shape |
|---|---|
| `bnpl_accounts` *(new)* | `{ userId, name, dueDay }` |
| `bills` *(existing)* | purchases are ordinary bill documents carrying `bnplAccountId` |

A purchase **is** a recurring bill. That means `computeBillsInPeriod` already generates its installments, `payments` already stores its paid-state, and every existing index and query keeps working. An **absent** `bnplAccountId` means "ordinary bill", so no data migration and no backfill — pre-existing rows are already correct.

The split is spelled in exactly one place, `partitionBills`, which every consumer of `bill.getAll` now routes through.

## The consolidation invariant — and where it actually lives

`recurrence.dtstart` is **derived server-side** from the account's `dueDay`; the client never sends it. `bill.create` accepts a raw recurrence, so purchase mutations live in `bnplRouter` rather than `billRouter` — `billRouter` can't mint a BNPL item by accident, and `bill.update` / `bill.delete` / `bill.assignGroup` now refuse to touch one.

**Derivation alone turned out to be insufficient, and review caught it.** The month-end clamp is lossy, and `monthlyOccurrencesInPeriod` re-derives its target day from the stored anchor:

- `dueDay: 31`, first due **February** → anchor clamps to Feb 28 → fires on the 28th **forever**
- same account, first due **March** → anchor 31 → fires on the 31st

One account, two occurrence days, **two statements every month** — the exact thing the design existed to prevent. The second one silently vanished from the UI and could never be marked paid.

The invariant now lives at the point statements are *formed*: `groupStatements` keys on **(account, calendar month)** and dates each statement at the account's `dueDay` clamped into that month, never at an occurrence's own day. Anchor drift became invisible rather than impossible. Side benefit: every paid-marker for a statement now lands on the same derived day, which is what makes the due-day marker shift land exactly.

## What's included

- **`bnpl_accounts` + `bnplRouter`** — account CRUD, purchase CRUD, and a due-day change that fans out across every purchase's `dtstart`.
- **`/bnpl`** (`bnplManager` + `bnplAccountCard`) — accounts, their current statement with a paid toggle, and each purchase with monthly amount and `3 of 6` progress.
- **Statement-level paid state** — `payment.markStatementPaid` / `markStatementUnpaid` write one `payments` marker per purchase due that month. Same collection as ordinary bills; presence = paid.
- **Dashboard** — one roll-up row per account per period (`billList`), and summary cards that count each account's statement as **1**, not N.
- **`bnpl-utils.ts`** — the pure layer: `deriveStatementDtstart`, `groupStatements`, `statementRemaining`, `isStatementPaid`, `installmentProgress`.
- **Vitest** — the repo's first test framework (`pnpm test` / `pnpm test:watch`), 41 tests over the pure helpers.

## Design decisions

- **Out of the itemized list, still in the totals.** The bill list's invariant — *section subtotals sum to the card's outgoing total* — would break the moment a counted amount stopped being itemized, so the roll-up row is itemized; it just collapses N purchases into 1.
- **One account-level `dueDay`**, not per-item. Providers bill one date; per-item days would let a split statement be entered by hand.
- **`Remaining` counts a statement's *unpaid purchases*, not the whole amount.** Markers are per-purchase underneath, so a statement settled at ₱3,000 that later gains a ₱500 purchase owes ₱500 — not ₱3,500 again.
- **Account deletion asks:** cascade-delete the purchases (and their payment history) or keep them as ordinary bills. The keep path `$unset`s `bnplAccountId`, which is exactly the "ordinary bill" state.
- **Changing an account's due day shows a confirmation** naming how many purchases will move, since it rewrites every schedule *and* shifts stored paid-markers.
- **A purchase edit that moves `dtstart` deletes its markers** rather than shifting them — shifting would misattribute a payment to the wrong month. Shrinking tenure deletes only markers past the new final occurrence.

## Code review (max) — addressed in this PR

Beyond the consolidation break above:

- **`deletePurchase` had no purchase guard** — passing an ordinary bill's id deleted that bill *and its entire payment history*, reporting success. Same gap in `bill.delete` and `bill.assignGroup`.
- **`purchaseCountFor` read "still loading" as "zero purchases"** — cards render when `bnpl.getAll` lands, before `bill.getAll`. The delete dialog then claimed "This account has no purchases", disabled the safe button, and labelled the red one "Delete account" — which wipes them all. Dialogs now gate on `purchasesLoaded`.
- **Statement roll-up rows never consulted `paidKeys`** — a settled statement looked identical to an unsettled one, directly under a card reporting it as ₱0 remaining.
- **`accounts` in the all-or-nothing loading guard** — a failing `bnpl.getAll` blanked the whole dashboard grid permanently, for users with no BNPL accounts at all.
- **The statement window opened at *today*** — a statement whose due date passed unpaid dropped off `/bnpl`, which holds the only statement toggle in the app, making it unsettleable. Now opens at the start of the current month.
- **Paid-marker integrity** across due-day changes, purchase edits, tenure shrinks, and both account-delete branches — markers keyed on `(billId, occurrenceDate)` are stranded by anything that moves an occurrence.
- Also: a `dtstart`-less row crashing the page instead of skipping one row; concurrent statement toggles stranding a permanently-disabled button; `$exists: false` disagreeing with the client's truthiness check on an explicit `null`; an off-by-one greying purchases as "Done" a month early; and a local-clock read that defaulted the first statement month to the *previous* one in Manila.

## Dates: `@date-fns/utc`

This branch's month arithmetic hand-rolled `Date.UTC(...)`. It now delegates to date-fns via **`UTCDate`**, which carries the UTC frame in the *value* — date-fns rebuilds results through `Symbol.for("constructDateFrom")`, so a whole chain reads UTC fields with no `{ in: … }` to pass at each site and none to forget. `formatUtcDate` dropped its local reinterpretation for the same reason. Results are unwrapped to plain `Date`s so the subclass never reaches MongoDB or SuperJSON.

`monthlyOccurrencesInPeriod` lost its manual month-index arithmetic in the process.

## Verification

- **41 tests** (`pnpm test`) · `pnpm exec tsc --noEmit` clean · `eslint` clean on changed files (3 pre-existing warnings in `bill.ts` untouched)
- Suite green under **UTC, Pacific/Kiritimati (+14), Pacific/Midway (−11), America/Santiago, Asia/Manila, America/Los_Angeles**
- **Mutation-checked:** removing the `UTCDate` wrapper fails 20 of 41 in Midway and 7 in Manila while still passing in UTC — so the timezone tests are load-bearing, not incidentally green

> [!IMPORTANT]
> **Not exercised in a browser.** Unlike previous PRs here, there was no live verification — no auth, no database, no browser in this run. The pure layer is well covered; **tRPC routers have no test harness at all**, and both paid-marker bugs on this branch lived in exactly that layer. Worth driving before merge:
>
> 1. **Purchase edit + markers** — 6-month purchase starting two months ago, both elapsed statements paid, then move the first month forward one. Statement must not read paid; `payments` should hold no rows on dates nothing renders. Repeat with tenure shrunk below the paid count.
> 2. **Purchase dialog state** — Add → reopen "Add purchase"; Edit → cancel → "Add purchase". Empty both times.
> 3. **Due-day change** with two purchases and one paid month — both move, paid state survives, exactly one roll-up row.
> 4. **Money invariant** — section subtotals + roll-up = "going out", still true after hiding a bill with the eye icon.
> 5. `/bnpl` while signed out redirects; a pre-existing user's dashboard is unchanged.

## Deferred follow-ups

- **`bnpl.update` is untransacted** — four sequential writes (account `$set`, purchase `bulkWrite`, marker `bulkWrite`). A mid-sequence failure leaves purchases split across two due days with markers unshifted. Fixing it needs Mongo sessions, which this repo uses nowhere.
- **No tRPC router test harness** (`mongodb-memory-server`) — the one layer with no coverage is the one that produced this branch's subtlest bugs.
- **`userId` index on `bnpl_accounts`**.
- **`pnpm test` in a pre-commit gate**, and a `test:tz` script sweeping offsets — a UTC-only run would have shipped the date bug clean.
- The **deeper consolidation fix**: store only the first *month* and derive the day at read time, making drift unrepresentable and removing `bnpl.update`'s fan-out entirely.

## Design docs

- `docs/superpowers/specs/2026-08-26-bnpl-accounts-design.md`
- `docs/superpowers/plans/2026-08-26-bnpl-accounts.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
