### PR TITLE
chore: clear all ESLint warnings and ratchet lint to zero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,11 @@ pnpm test:watch       # Vitest watch mode
 Vitest covers pure helpers only — there is no harness for tRPC routers or
 components, so router logic is verified by review and by hand (tracked in #47).
 
-`pnpm check` runs the three gates in order — `tsc --noEmit && eslint . && vitest
-run` — so the fastest decisive signal comes first. Note that Next 16 removed
+`pnpm check` runs the three gates in order — `pnpm typecheck && pnpm lint &&
+pnpm test` — so the fastest decisive signal comes first. It delegates to those
+three scripts rather than inlining the tools because CI runs the same three as
+separate parallel jobs; sharing one definition per gate keeps them from
+drifting. Lint is ratcheted at `--max-warnings 0`. Note that Next 16 removed
 `next lint`, so ESLint is invoked directly; `eslint-config-next` must stay in
 lockstep with `next`, and its flat config is consumed via its native
 `eslint-config-next/core-web-vitals` entrypoint (no `FlatCompat` shim).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,23 @@ import tseslint from "typescript-eslint";
 // its own ignores (`.next/**`, `out/**`, `build/**`, `next-env.d.ts`), so this
 // file does not repeat them.
 export default tseslint.config(
+  // Flat config does not read .gitignore (or .git/info/exclude) — it
+  // default-ignores only node_modules. Everything else gitignored has to be
+  // named here or it gets linted. The worktree entries matter most: agent
+  // sessions check out whole nested copies of this repo there, so without them
+  // `eslint .` reports another branch's files as this one's and
+  // `--max-warnings 0` passes or fails depending on who has a worktree open.
+  // `.next`, `out`, `build`, and `next-env.d.ts` come from nextVitals already.
+  {
+    ignores: [
+      ".claude/worktrees/**",
+      ".worktrees/**",
+      ".superpowers/**",
+      "coverage/**",
+      ".vercel/**",
+      ".playwright-mcp/**",
+    ],
+  },
   ...nextVitals,
   {
     files: ["**/*.ts", "**/*.tsx"],
@@ -25,7 +42,7 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": [
         "warn",
-        { argsIgnorePattern: "^_" },
+        { argsIgnorePattern: "^_", ignoreRestSiblings: true },
       ],
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-misused-promises": [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,7 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": [
         "warn",
-        { argsIgnorePattern: "^_", ignoreRestSiblings: true },
+        { argsIgnorePattern: "^_" },
       ],
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-misused-promises": [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,10 +40,7 @@ export default tseslint.config(
         "warn",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },
       ],
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        { argsIgnorePattern: "^_" },
-      ],
+      "@typescript-eslint/no-unused-vars": "warn",
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-misused-promises": [
         "error",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mongodb": "^6.21.0",
     "next": "^16.2.2",
     "next-themes": "^0.4.6",
+    "radashi": "^12.9.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-day-picker": "9.8.1",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "check": "tsc --noEmit && eslint . && vitest run",
+    "check": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "next dev --turbo",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "preview": "next build && next start",
     "start": "next start",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      radashi:
+        specifier: ^12.9.1
+        version: 12.9.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3271,6 +3274,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  radashi@12.9.1:
+    resolution: {integrity: sha512-HCvrL1Ag7qnyH11UiSWQaEIiizJ7kldHjBw63aELoum7C8nQrSLqotLDuKKvoRPtO0w8azCzUQcL3yrU3lBksw==}
+    engines: {node: '>=16.0.0'}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -6795,6 +6802,8 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radashi@12.9.1: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,7 @@
-export default {
+const config = {
   plugins: {
     "@tailwindcss/postcss": {},
   },
 };
+
+export default config;

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,6 @@
 /** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
-export default {
+const config = {
   plugins: ["prettier-plugin-tailwindcss"],
 };
+
+export default config;

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import type * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { ObjectId, type WithoutId } from "mongodb";
+import { ObjectId, type Db, type WithoutId } from "mongodb";
 import type { Simplify } from "type-fest";
 import { z } from "zod";
 import { RecurringBillSchema, SingleBillSchema } from "~/schemas/bill";
@@ -57,7 +57,7 @@ type GroupDoc = {
 // Resolves a groupId string from input into an ObjectId after checking the
 // group belongs to the requesting user. Returns null if input is null/empty.
 async function resolveGroupId(
-  ctx: { db: import("mongodb").Db; session: { user: { id: string } } },
+  ctx: { db: Db; session: { user: { id: string } } },
   rawGroupId: string | null | undefined,
 ): Promise<ObjectId | null> {
   if (rawGroupId == null || rawGroupId === "") return null;

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -125,9 +125,9 @@ export const billRouter = createTRPCRouter({
       }
 
       const groupOid = await resolveGroupId(ctx, input.data.groupId);
-      const update: Record<string, unknown> = {
-        ...omit(input.data, ["groupId"]),
-      };
+      // `omit` already returns a fresh object, so this is safe to mutate below
+      // without a further spread or clone.
+      const update: Record<string, unknown> = omit(input.data, ["groupId"]);
       if (groupOid !== null) update.groupId = groupOid;
 
       const setOps: Record<string, unknown> = { $set: update };

--- a/src/server/api/routers/bill.ts
+++ b/src/server/api/routers/bill.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { ObjectId, type Db, type WithoutId } from "mongodb";
+import { omit } from "radashi";
 import type { Simplify } from "type-fest";
 import { z } from "zod";
 import { RecurringBillSchema, SingleBillSchema } from "~/schemas/bill";
@@ -124,8 +125,9 @@ export const billRouter = createTRPCRouter({
       }
 
       const groupOid = await resolveGroupId(ctx, input.data.groupId);
-      const { groupId: _groupId, ...rest } = input.data;
-      const update: Record<string, unknown> = { ...rest };
+      const update: Record<string, unknown> = {
+        ...omit(input.data, ["groupId"]),
+      };
       if (groupOid !== null) update.groupId = groupOid;
 
       const setOps: Record<string, unknown> = { $set: update };
@@ -189,10 +191,9 @@ export const billRouter = createTRPCRouter({
     .input(InputBillSchema)
     .mutation(async ({ ctx, input }) => {
       const groupOid = await resolveGroupId(ctx, input.groupId);
-      const { groupId: _groupId, ...rest } = input;
 
       await ctx.db.collection<WithoutId<BillEvent>>("bills").insertOne({
-        ...rest,
+        ...omit(input, ["groupId"]),
         userId: new ObjectId(ctx.session.user.id),
         ...(groupOid !== null ? { groupId: groupOid } : {}),
       });


### PR DESCRIPTION
## Summary

Clears the 6 remaining ESLint warnings and ratchets `lint` at `--max-warnings 0` so they can't drift back. CI's `lint` job now enforces it.

## The fixes

Only two were really about the code:

| Where | Fix |
| --- | --- |
| `bill.ts:60` | inline `import("mongodb").Db` hoisted onto the existing top-level mongodb import |
| `ui/form.tsx:4` | `LabelPrimitive` imported as a value though only used in type positions (auto-fixed) |
| `postcss.config.js`, `prettier.config.js` | anonymous default exports **named**, rather than switching the rule off for config files — which would have weakened it everywhere |

### The `_groupId` pair: replaced with `radashi`'s `omit`

The two warnings came from the omit-a-key idiom, where the binding exists only to be discarded:

```ts
const { groupId: _groupId, ...rest } = input;
```

Rather than teach the linter to tolerate that, both sites now state the intent directly:

```ts
omit(input, ["groupId"])
```

These were the **only two** rest-sibling destructures in the codebase, so the `ignoreRestSiblings: true` exemption an earlier commit added is reverted — with no callers left it would only permit the idiom being retired. `pnpm check` stays at zero warnings without it.

#### Checked before switching, because `Omit` has a sharp edge

`Omit<T, K>` does **not** distribute over unions; object rest-destructuring does. For `InputBill`:

```ts
{ title, amount?, groupId? } & ({ type: "single"; date } | { type: "recurring"; recurrence })
```

`keyof (A | B)` is `keyof A & keyof B`, so `Omit` keeps only the keys common to both members — **`date` and `recurrence` disappear from the type.** The old idiom really was the better-typed of the two, which I verified rather than assumed.

It makes no difference here, and the reason is worth recording: `BillEvent` is *itself* declared as `Simplify<{…} & Omit<InputBill, "groupId">>`, so the insert target had already collapsed the same union. This compiles on `main` today:

```ts
const missingSchedule: WithoutId<BillEvent> = {
  userId: new ObjectId(),
  title: "no date, no recurrence",
  type: "single",     // ← no date, no recurrence, accepted
};
```

So nothing is lost that wasn't already lost. That pre-existing hole is filed as **#55** — and `src/types/index.ts` already documents this exact trap and works around it with an explicit union, so the fix pattern is established in the repo.

Runtime behaviour is unchanged: radashi's `omit` copies every key but the named one, exactly as the rest element did. New dependency: `radashi@^12.9.1`.

## A non-determinism found while ratcheting

Worth flagging, because it would have made the ratchet flaky and gotten it reverted.

ESLint 9 flat config **does not read `.gitignore`** — or `.git/info/exclude`. It default-ignores only `node_modules`. So `eslint .` was walking `.claude/worktrees/<branch>/`, a whole nested checkout another agent session had open, and reporting *that branch's* unfixed files as this branch's:

```
.claude/worktrees/fix+bill-delete-double-toast/postcss.config.js
  1:1  warning  Assign object to a variable before exporting as module default
```

With `--max-warnings 0` the gate would then pass or fail depending on whether anyone happened to have a worktree open — and **only locally**, since CI checks out fresh and never sees them. A gate that fails for reasons unrelated to your change is one people learn to ignore. Nested-checkout and tooling directories are now ignored explicitly, with the reasoning in the config.

## `check` now delegates

```diff
- "check": "tsc --noEmit && eslint . && vitest run",
+ "check": "pnpm typecheck && pnpm lint && pnpm test",
```

CI runs those same three scripts as separate parallel jobs. Sharing one definition per gate means the local gate and CI can't drift — previously `check` inlined `eslint .` while CI ran `pnpm lint`, so the new `--max-warnings 0` would have applied in CI but not locally.

## Verification

- `pnpm check` exits **0** (typecheck, lint at zero warnings, 41 tests)
- `pnpm build` succeeds, and the emitted CSS still contains **499 `--tw-` properties** — confirming the `postcss.config.js` rename is inert rather than assuming it
- prettier's tailwind plugin still sorts classes, confirming the `prettier.config.js` rename is inert too (probed with an unsorted `className`)

## One thing left unclean, deliberately

`ui/form.tsx` still fails `format:check`. It was already one of the 27 drifted files before this change, so that's not a regression, and formatting it would add **81 lines** of shadcn semicolon churn over a one-line type-import fix. Covered by #51, which formats all 27 at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
