### PR TITLE
fix: stop retrying queries that failed with a client error

### DIFF
--- a/src/trpc/query-client.test.ts
+++ b/src/trpc/query-client.test.ts
@@ -1,0 +1,62 @@
+import { TRPCClientError } from "@trpc/client";
+import { describe, expect, it } from "vitest";
+import { shouldRetryQuery } from "~/trpc/query-client";
+
+/**
+ * Builds the error a failed procedure actually hands React Query: a real
+ * `TRPCClientError` carrying the server's error shape, not a hand-rolled
+ * stand-in. `httpStatus` is what the predicate reads, so a fake object with the
+ * right keys would pass while proving nothing about the real error class.
+ */
+function trpcError(code: string, httpStatus: number) {
+  return TRPCClientError.from({
+    error: {
+      message: code,
+      code: -32600,
+      data: { code, httpStatus, path: "bill.getById" },
+    },
+  });
+}
+
+describe("shouldRetryQuery", () => {
+  it("does not retry a bill that no longer exists", () => {
+    expect(shouldRetryQuery(0, trpcError("NOT_FOUND", 404))).toBe(false);
+  });
+
+  it("does not retry when the caller is not allowed", () => {
+    expect(shouldRetryQuery(0, trpcError("UNAUTHORIZED", 401))).toBe(false);
+    expect(shouldRetryQuery(0, trpcError("FORBIDDEN", 403))).toBe(false);
+  });
+
+  it("does not retry any other client error", () => {
+    expect(shouldRetryQuery(0, trpcError("BAD_REQUEST", 400))).toBe(false);
+    expect(shouldRetryQuery(0, trpcError("CONFLICT", 409))).toBe(false);
+  });
+
+  it("retries a timeout or a rate limit, which do clear on their own", () => {
+    expect(shouldRetryQuery(0, trpcError("TIMEOUT", 408))).toBe(true);
+    expect(shouldRetryQuery(0, trpcError("TOO_MANY_REQUESTS", 429))).toBe(true);
+  });
+
+  it("retries a server error", () => {
+    expect(shouldRetryQuery(0, trpcError("INTERNAL_SERVER_ERROR", 500))).toBe(
+      true,
+    );
+  });
+
+  it("retries a bare network failure, which carries no error shape", () => {
+    expect(shouldRetryQuery(0, new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("still gives up after three attempts", () => {
+    const offline = new TypeError("Failed to fetch");
+    expect(shouldRetryQuery(2, offline)).toBe(true);
+    expect(shouldRetryQuery(3, offline)).toBe(false);
+  });
+
+  it("gives up on a client error immediately, not after the third attempt", () => {
+    // The bug this guards: a NOT_FOUND used to cost four requests and ~7s of
+    // backoff before surfacing, because the count was the only thing consulted.
+    expect(shouldRetryQuery(0, trpcError("NOT_FOUND", 404))).toBe(false);
+  });
+});

--- a/src/trpc/query-client.ts
+++ b/src/trpc/query-client.ts
@@ -2,7 +2,49 @@ import {
   defaultShouldDehydrateQuery,
   QueryClient,
 } from "@tanstack/react-query";
+import { isTRPCClientError } from "@trpc/client";
 import SuperJSON from "superjson";
+import type { AppRouter } from "~/server/api/root";
+
+const MAX_ATTEMPTS = 3;
+
+const CLIENT_ERROR_FIRST_STATUS = 400;
+const SERVER_ERROR_FIRST_STATUS = 500;
+
+// A client error is the server saying "this request is wrong", which no amount
+// of repeating will fix -- except these two, which say "wrong *for now*".
+const RETRYABLE_CLIENT_STATUSES = new Set([
+  408, // Request Timeout
+  429, // Too Many Requests
+]);
+
+/**
+ * Retries only failures that a later attempt could plausibly resolve.
+ *
+ * Without this, the query default of three retries applies to 4xx responses
+ * too, so a NOT_FOUND costs four requests and ~7s of backoff before it ever
+ * reaches the UI. Errors with no tRPC shape -- a dropped connection, DNS
+ * failure -- are exactly what retrying is for, so they keep the default.
+ */
+export function shouldRetryQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (isUnretryableClientError(error)) return false;
+  return failureCount < MAX_ATTEMPTS;
+}
+
+function isUnretryableClientError(error: unknown): boolean {
+  if (!isTRPCClientError<AppRouter>(error)) return false;
+
+  const status = error.data?.httpStatus;
+  if (status === undefined) return false;
+  if (RETRYABLE_CLIENT_STATUSES.has(status)) return false;
+
+  return (
+    status >= CLIENT_ERROR_FIRST_STATUS && status < SERVER_ERROR_FIRST_STATUS
+  );
+}
 
 export const createQueryClient = () =>
   new QueryClient({
@@ -11,6 +53,7 @@ export const createQueryClient = () =>
         // With SSR, we usually want to set some default staleTime
         // above 0 to avoid refetching immediately on the client
         staleTime: 30 * 1000,
+        retry: shouldRetryQuery,
       },
       dehydrate: {
         serializeData: SuperJSON.serialize,


### PR DESCRIPTION
## Why

React Query's default of three retries applies to every query failure, including ones the server has already answered definitively. A `NOT_FOUND` therefore costs **four requests and ~7s of exponential backoff** (1s/2s/4s) before it reaches the UI.

That delay is what made #56 take seven seconds instead of two hundred milliseconds. #56 fixes the one query that shouldn't have been refetched; this fixes the reason the mistake was so expensive, for every query in the app.

## What

Retry only failures a later attempt could plausibly resolve:

| Failure | Retried | Why |
| --- | --- | --- |
| 4xx (404, 401, 403, 400, 409, …) | no | The server says the request is wrong; repeating won't change that |
| 408 Request Timeout | yes | Says "wrong *for now*" — backoff is the right answer |
| 429 Too Many Requests | yes | Same |
| 5xx | yes | Server-side, may well be transient |
| No tRPC shape (dropped connection, DNS) | yes | Exactly what retrying is for |

Keyed on the **HTTP status class** rather than an enumerated list of tRPC codes. An enumerated list is open — a code nobody thought to list still quietly costs four round trips. A range is closed: every 4xx fails fast unless explicitly excepted.

Mutations are unaffected; they already default to no retries.

## Tests

Written test-first — 8 cases in `src/trpc/query-client.test.ts`, verified failing (`shouldRetryQuery is not a function`) before the implementation existed. They build real `TRPCClientError`s via `TRPCClientError.from()` rather than hand-rolled look-alikes, so they exercise the actual error class the client hands React Query.

Covered: each unretryable client error, both retryable exceptions, a server error, a bare network failure, the attempt ceiling, and the regression itself — that a client error gives up immediately rather than on the third attempt.

`pnpm check` green: typecheck, lint at `--max-warnings 0`, 49 tests.

## Relationship to #56

Independent — different files, no conflict, either can merge first. #56 removes the refetch that shouldn't happen; this one makes the whole class of mistake cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
